### PR TITLE
Add README, including Contentful-related developer usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+## About
+
+This is the new website of the Austin Convention Center Department, currently under active development. The project is being led by a team in the City's [Design, Technology, and Innovation Fellows program][dti].
+
+We're using [sprints], and you're welcome to check out [our Trello board][trello].
+
+[dti]: http://cityofaustin.github.io/innovation-fellows/
+[sprints]: https://en.wikipedia.org/wiki/Scrum_(software_development)
+[trello]: https://trello.com/b/6c52YDzi/acc-pec
+
+## Architecture
+
+This project implements a decoupled CMS, which you can read about in [our Medium post][medium]. It uses [Contentful][], "a developer-friendly, API-first CMS," as the content editor, and [Jekyll][] as the static site generator.
+
+The same source will produce the static sites for both austinconventioncenter.com and palmereventscenter.com, using a separate Contentful space for each.
+
+<!-- TODO: Detail Continuous Deployment and AWS -->
+
+[medium]: https://medium.com/city-of-austin-design-technology-innovation/how-were-thinking-about-content-management-for-city-government-88f563497096
+[contentful]: https://www.contentful.com
+[jekyll]: https://jekyllrb.com
+
+## Quick Start
+
+`git clone`, `bundle install`, `jekyll contentful`, `jekyll serve`
+
+## Contributing
+
+Refer to the [Developer Guide][], particularly the Git workflow.
+
+[Developer Guide]: https://github.com/cityofaustin/developer-guide
+
+## Working with Contentful
+
+Start with understanding the concepts outlined in [Contentful's developer docs](https://www.contentful.com/developers/docs/).
+
+<!-- TODO: Commit content model/type JSON to repo for bootstrap. -->
+
+### Importing content
+
+Contentful entries are made available to Jekyll using the official [jekyll-contentful-data-import][] gem, which provides the `jekyll contentful` command to download entries into [_data](_data).
+
+<!-- TODO: Add option to download the latest data from GitHub w/o Contentful keys. -->
+
+To run `jekyll contentful`, you'll need to set the `CONTENTFUL_SPACE_ID` and `CONTENTFUL_ACCESS_TOKEN` environment variables from the API keys found in the Contentful editor. Do not commit those keys; we recommend using an environment switcher like [direnv][] and adding the dotfile (e.g. `.envrc`) to your **global** gitignore.
+
+Git ignores the imported YAML files by default; avoid committing them to topic branches and master.
+
+[jekyll-contentful-data-import]: https://github.com/contentful/jekyll-contentful-data-import
+[direnv]: http://direnv.net
+
+### Rendering content
+
+A Jekyll generator in [_plugins](_plugins/generators/contentful.rb) creates [Collections and Documents][collections] from the Section and Page content types.
+
+Templates and layouts render Contentful attributes using `page.contentful` in [Liquid][]. The [front matter defaults][] in [_config.yml](_config.yml) define the layouts used to render pages in a given collection and by default.
+
+For each page, the generator also looks in [_custom](_custom) for a template with a matching `contentful_id` in its front matter. If a match is found, the generator renders the page with template instead of the default layout.
+
+To render specific content outside of a page (such as a particular menu), `site.contentful` exposes the contents of the entire data file, and plays nicely with [Jekyll's `where` filters][where]. See an example in [_includes/header.html](_includes/header.html).
+
+Use the `jekyll build` and `jekyll serve` commands as you would normally.
+
+[collections]: https://jekyllrb.com/docs/collections/
+[liquid]: http://liquidmarkup.org
+[front matter defaults]: https://jekyllrb.com/docs/configuration/#front-matter-defaults
+[where]: https://jekyllrb.com/docs/templates/
+
+<!-- ## Deploying (TODO) -->
+
+## Credits
+
+* Our prototyping wouldn't be nearly as solid without the [U.S. Web Design Standards][uswds] developed by [18F][] :heart:
+
+[uswds]: https://standards.usa.gov
+[18f]: https://github.com/18f/web-design-standards
+

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,7 @@ exclude:
   - Gemfile.lock
   - Procfile
   - Rakefile
+  - README
   - vendor
 
 contentful:


### PR DESCRIPTION
The README provides a quick explanation the project to anyone who
might find it on a GitHub, and more in-depth usage instructions to
developers working on the project.

I decided while writing it to add \_data/contentful to the .gitignore,
instead of committing the YAML files it contains to master; that
change has since been committed to master. My thinking is that
committing changes to the data file in our topic branches could easily
become noisy and distracting, and even potentially introduce
cumbersome merge conflicts. The downside to _not_ committing it is
that every developer on the project currently needs Contentful API
keys to sync the updated data; especially once the data stabilizes
(i.e. by the time the new website launches), that might not be ideal.
At that point, our continuous deployment process could
push changes to the data file to a non-master branch, and we could
replace `jekyll contentful` with a command to simply pull changes from
that branch, no keys required.

The new README includes some inline TODO comments about what's still
left to add.