### PR TITLE
Configure Circle to download s3_website.jar during dependency phase

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,16 @@ general:
     only:
       - master
 
+dependencies:
+  post:
+    - |
+      S3_WEBSITE_GEM="$(bundle show s3_website)" \
+      S3_WEBSITE_JAR="$S3_WEBSITE_GEM/s3_website-${S3_WEBSITE_GEM##*-}.jar"; \
+      if [ ! -f $S3_WEBSITE_JAR ]; then
+        wget --no-verbose --output-document $S3_WEBSITE_JAR \
+        "https://github.com/laurilehmijoki/s3_website/releases/download/v${S3_WEBSITE_GEM##*-}/s3_website.jar"
+      fi
+
 test:
   override:
     - "bundle exec jekyll contentful"


### PR DESCRIPTION
The `s3_website push` deploy command automatically downloads the .jar
file that does s3_website's heavy lifting, but the download is not
cached by Circle. This is a workaround to download the file during
the build's dependency phase, so that it'll be cached.

It's obviously a made somewhat fragile by being contigent on
s3_website's internals (https://github.com/laurilehmijoki/s3_website/blob/v2.15.1/bin/s3_website#L200-L245),
so I might open an issue on s3_website suggesting the addition of an
`s3_website download` or similar command that we could use instead.