### PR TITLE
Add format_phone Liquid filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 ruby "2.3.1"
 
+gem "activesupport"
 gem "jekyll"
 gem "jekyll-assets"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.4.0)
     aws-sdk (2.6.14)
       aws-sdk-resources (= 2.6.14)
@@ -37,6 +42,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.1)
     http_parser.rb (0.6.0)
+    i18n (0.7.0)
     jekyll (3.3.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -70,6 +76,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    minitest (5.9.1)
     multi_json (1.12.1)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
@@ -90,6 +97,9 @@ GEM
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     thor (0.19.1)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -98,6 +108,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   jekyll
   jekyll-assets
   jekyll-contentful-data-import

--- a/_plugins/filters/format_phone.rb
+++ b/_plugins/filters/format_phone.rb
@@ -1,0 +1,11 @@
+require 'active_support'
+
+module Jekyll
+  module FormatPhone
+    def format_phone(input)
+      ActiveSupport::NumberHelper.number_to_phone(input.gsub(/[^\d]/, ""), area_code: true)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::FormatPhone)


### PR DESCRIPTION
Uses ActiveSupport's [number_to_phone][] helper.

`{{ "5555555555" | format_phone }}`

[number_to_phone]: http://api.rubyonrails.org/classes/ActiveSupport/NumberHelper.html#method-i-number_to_phone