### PR TITLE
Create a url_for tag to match Contentful objects to document URLs

### DIFF
--- a/_includes/components/breadcrumbs.html
+++ b/_includes/components/breadcrumbs.html
@@ -1,6 +1,6 @@
 <div class="acc-breadcrumbs {{ page.breadcrumbs[0].slug }}">
   <div class="usa-nav-container acc-breadcrumbs-container">
-  <a href="{{ breadcrumb.url }}" class="acc-breadcrumb acc-breadcrumb-home">Home</a>
+  <a href="{{ site.baseurl }}/" class="acc-breadcrumb acc-breadcrumb-home">Home</a>
   {% for breadcrumb in page.breadcrumbs %}
     <a href="{{ breadcrumb.url }}" class="acc-breadcrumb">{{ breadcrumb.title }}</a>
   {% endfor %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,7 +27,7 @@
             {% assign footer_links = site.contentful.menu | where: "name", "Footer" | first %}
             {% for item in footer_links.items %}
             <li>
-              <a href="{{site.baseurl}}/{{item.title|slugify}}">
+              <a href="{% url_for item %}">
                 <span>{{item.title}}</span>
               </a>
             </li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,8 +17,8 @@
         {% assign menu = site.contentful.menu | where: "name", "Header" | first %}
         {% for item in menu.items %}
           <li>
-            <a class="usa-nav-link acc-nav-link {{item.slug}}" href="/{{item.slug}}/">
-              <span>{{item.title}}</span>
+            <a class="usa-nav-link acc-nav-link {{item.slug}}" href="{% url_for item %}">
+              {{item.title}}
             </a>
           </li>
         {% endfor %}

--- a/_plugins/tags/url_for.rb
+++ b/_plugins/tags/url_for.rb
@@ -1,0 +1,28 @@
+class UrlFor < Liquid::Tag
+  Syntax = /(#{Liquid::VariableSignature}+)/o
+
+  def initialize(tag_name, markup, tokens)
+    super
+    if markup =~ Syntax
+      @var = markup
+    else
+      raise SyntaxError.new("Syntax Error in 'url_for' - Valid syntax: url_for [var]")
+    end
+  end
+
+  def render(context)
+    site = context.registers[:site]
+    object = Liquid::Variable.new(@var).render(context)
+
+    if object.respond_to?(:key?) && object.key?("sys")
+      id = object["sys"]["id"]
+
+      site.docs_to_write.each do |doc|
+        return doc.url if doc.data["contentful"] && doc.data["contentful"]["sys"]["id"] == id
+      end
+    end
+  end
+
+end
+
+Liquid::Template.register_tag("url_for", UrlFor)


### PR DESCRIPTION
Menus (or any Contentful objects that reference arbtirary sections
and pages) can't always know or guess the full URL of each of their
documents, so url_for provides a way to match a given Contentful ID
to an existing Document and return its URL. Named after the Rails
helper, but way less fancy.