### PR TITLE
Create rake task to import event listing data from Socrata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ _site
 .sass-cache
 .jekyll-metadata
 _data/contentful
+_data/socrata
 node_modules/

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "jekyll"
 gem "jekyll-assets"
 gem "rake"
 gem "s3_website"
+gem "soda-ruby"
 
 group :jekyll_plugins do
   gem "jekyll-contentful-data-import"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
       addressable (~> 2)
     ffi (1.9.14)
     forwardable-extended (2.6.0)
+    hashie (3.4.6)
     http (1.0.4)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
@@ -78,6 +79,7 @@ GEM
     mercenary (0.3.6)
     minitest (5.9.1)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     rack (1.6.4)
@@ -93,9 +95,15 @@ GEM
       thor (~> 0.18)
     safe_yaml (1.0.4)
     sass (3.4.22)
+    soda-ruby (0.2.21)
+      hashie (~> 3.4.2)
+      multipart-post (~> 2.0.0)
+      sys-uname (~> 1.0.2)
     sprockets (3.6.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
+    sys-uname (1.0.3)
+      ffi (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -114,6 +122,7 @@ DEPENDENCIES
   jekyll-contentful-data-import
   rake
   s3_website
+  soda-ruby
 
 RUBY VERSION
    ruby 2.3.1p112

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,18 @@ require 'bundler/setup'
 require 'jekyll'
 require 'jekyll-contentful-data-import'
 require './_plugins/mappers/content_block_mapper'
+require './lib/accd/calendar'
 
-desc "Import Contentful Data with Custom Mappers"
+desc "Import Contentful data with custom mappers"
 task :contentful do
   Jekyll::Commands::Contentful.process([], {}, Jekyll.configuration['contentful'])
+end
+
+desc "Import event listing data from Socrata (data.austintexas.gov)"
+task :calendar do
+  ACCD::Calendar.import(Jekyll.configuration)
+end
+
+desc "Import all data"
+task :import => [:contentful, :calendar] do
 end

--- a/_config.yml
+++ b/_config.yml
@@ -18,10 +18,14 @@ sass:
 
 exclude:
   - bin
+  - circle.yml
   - config.ru
   - Gemfile
   - Gemfile.lock
+  - lib
   - node_modules
+  - package.json
+  - Rakefile
   - README
   - s3_website.yml
   - vendor

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ dependencies:
 
 test:
   override:
-    - "bundle exec jekyll contentful"
+    - "bundle exec rake import"
     - "bundle exec jekyll build"
 
 deployment:

--- a/lib/accd/calendar.rb
+++ b/lib/accd/calendar.rb
@@ -1,0 +1,29 @@
+require 'soda/client'
+require 'fileutils'
+require 'yaml'
+
+module ACCD
+  class Calendar
+
+    class << self
+      def import(config)
+        results = socrata_client.get("e43u-d7ev", "$limit": 5000)
+        path = File.join(config["source"], config["data_dir"], "socrata", "calendar", "accd.yaml")
+
+        FileUtils.mkdir_p(File.dirname(path))
+
+        File.open(path, "w") do |file|
+          file.write(YAML.dump({ "events" => results.map(&:to_hash) }))
+        end
+      end
+
+      def socrata_client
+        @socrata_client ||= SODA::Client.new({
+          domain: "data.austintexas.gov",
+          app_token: ENV["SOCRATA_APP_TOKEN"]
+        })
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Requires SOCRATA_APP_TOKEN environment variable.

Calendar only: `$ rake calendar`
Contentful and Calendar: `$ rake import`

Data goes to _data/socrata/calendar/accd.yaml.