### PR TITLE
Allow redirects to be specified in Contentful data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.3.1"
 gem "activesupport"
 gem "jekyll"
 gem "jekyll-assets"
+gem "jekyll-redirect-from"
 gem "rake"
 gem "s3_website"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
     jekyll-contentful-data-import (1.3.0)
       contentful (~> 0.8)
       jekyll (>= 2.5.0, < 4)
+    jekyll-redirect-from (0.11.0)
+      jekyll (>= 2.0)
     jekyll-sass-converter (1.4.0)
       sass (~> 3.4)
     jekyll-watch (1.5.0)
@@ -112,6 +114,7 @@ DEPENDENCIES
   jekyll
   jekyll-assets
   jekyll-contentful-data-import
+  jekyll-redirect-from
   rake
   s3_website
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ permalink: pretty
 
 gems:
   - jekyll-assets
+  - jekyll-redirect-from
 
 assets:
   sources:

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -78,6 +78,9 @@ module Jekyll
       doc.data["slug"] = slug
       doc.data["contentful"] = attributes
 
+      # Pass redirects from Contentful to jekyll-redirect-from
+      doc.data["redirect_from"] = attributes["redirectFrom"] if attributes["redirectFrom"]
+
       # Inherit breadcrumbs from parent section(s)
       doc.data["breadcrumbs"] = Array.new(section.metadata["breadcrumbs"] || []).push({
         "title" => attributes["title"],


### PR DESCRIPTION
Pages and Sections now include a redirectFrom attribute to specify
paths that should be redirected (such as /directions/floors.htm to
/facilities/plans/). Input is validated on the Contentful side and
set as the data attribute expected by jekyll-redirect-from.

https://github.com/jekyll/jekyll-redirect-from