### PR TITLE
Render press releases

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,6 +72,12 @@ defaults:
       permalink: "/calendar/:year/:month/"
   -
     scope:
+      type: press-releases
+    values:
+      layout: press_release
+      permalink: "/press-releases/:year/:month/:day/:title/"
+  -
+    scope:
       type: rooms
     values:
       layout: room

--- a/_custom/sections/press-releases.html
+++ b/_custom/sections/press-releases.html
@@ -1,0 +1,12 @@
+---
+layout: default
+contentful_id: 4S1U5bQghaQAaKQsqOKywe
+---
+
+<div class="usa-grid">
+  <ul>
+    {% for press_release in site.press-releases %}
+      <li><a href="{{press_release.url}}">{{ press_release.title }}</a></li>
+    {% endfor %}
+  </ul>
+</div>

--- a/_layouts/press_release.html
+++ b/_layouts/press_release.html
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+
+<div class="usa-grid">
+  <h2>{{ page.contentful.title }}</h2>
+
+  <h5>{{ page.contentful.byline }} on {{ page.contentful.date }}</h5>
+
+  {{ page.contentful.body | markdownify }}
+</div>

--- a/_layouts/press_release.html
+++ b/_layouts/press_release.html
@@ -9,3 +9,14 @@ layout: default
 
   {{ page.contentful.body | markdownify }}
 </div>
+
+{% if page.contentful.contact %}
+{% assign contact = page.contentful.contact %}
+  <div class="usa-grid">
+    <div class="usa-width-one-whole">
+      For more information, contact:<br>
+      {{ contact.name }}, {{ contact.title }}, Austin Convention Center Department<br>
+      {{ contact.phone | format_phone }} or <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+    </div>
+  </div>
+{% endif %}

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -31,6 +31,11 @@ module Jekyll
         generate_page(site, section, attributes)
       end
 
+      data["pressRelease"].each do |attributes|
+        attributes["date"] = attributes["date"].utc # Undo implicit time zone conversion
+        generate_page(site, site.collections["press-releases"], attributes)
+      end
+
       data["room"].each do |attributes|
         generate_page(site, site.collections["rooms"], attributes)
       end
@@ -84,6 +89,7 @@ module Jekyll
 
       doc.data["title"] = attributes["title"]
       doc.data["slug"] = slug
+      doc.data["date"] = attributes["date"] if attributes.key?("date")
       doc.data["contentful"] = attributes
 
       # Pass redirects from Contentful to jekyll-redirect-from


### PR DESCRIPTION
Each press release now renders as a page using the press_release
layout and blog-like URL that includes the date. They're added to a
press-releases collection corresponding to the Contentful section,
the index page of which  is rendered from _custom, much like the new
Calendar index. I still don't love _custom for this, but it works for
now.

Press release archive pages (by year) are not yet implemented but will
be added later.