### PR TITLE
Template accordion content blocks

### DIFF
--- a/_assets/javascripts/main.js
+++ b/_assets/javascripts/main.js
@@ -1,0 +1,1 @@
+//= require uswds/dist/js/uswds.min.js

--- a/_config.yml
+++ b/_config.yml
@@ -40,9 +40,10 @@ contentful:
         cda_query:
           limit: 1000
         content_types:
-          textBlock: ContentBlockMapper
+          accordionBlock: ContentBlockMapper
           contactBlock: ContentBlockMapper
           galleryBlock: ContentBlockMapper
+          textBlock: ContentBlockMapper
     # - pec:
     #     space: ENV_CONTENTFUL_PEC_SPACE_ID
     #     access_token: ENV_CONTENTFUL_PEC_ACCESS_TOKEN

--- a/_includes/components/content_blocks.html
+++ b/_includes/components/content_blocks.html
@@ -2,12 +2,14 @@
   <div class="content-block-list">
     {% for block in include.blocks %}
       {% case block.type %}
-        {% when "textBlock" %}
-          {% include components/content_blocks/text.html block=block %}
-        {% when "galleryBlock" %}
-          {% include components/content_blocks/gallery.html block=block %}
+        {% when "accordionBlock" %}
+          {% include components/content_blocks/accordion.html block=block %}
         {% when "contactBlock" %}
           {% include components/content_blocks/contact.html block=block %}
+        {% when "galleryBlock" %}
+          {% include components/content_blocks/gallery.html block=block %}
+        {% when "textBlock" %}
+          {% include components/content_blocks/text.html block=block %}
       {% endcase %}
     {% endfor %}
   </div>

--- a/_includes/components/content_blocks/accordion.html
+++ b/_includes/components/content_blocks/accordion.html
@@ -1,0 +1,15 @@
+{% assign accordion = include.block %}
+<ul class="usa-accordion">
+  {% for block in accordion.contentBlocks %}
+    {% if block.type != "textBlock" %}{% continue %}{% endif %}
+    {% assign id = block.title | slugify %}
+    <li>
+      <button class="usa-accordion-button" aria-controls="{{ id }}-{{ forloop.index }}">
+        {{ block.title }}
+      </button>
+      <div id="{{ id }}-{{ forloop.index }}" class="usa-accordion-content">
+        {{ block.text | markdownify }}
+      </div>
+    </li>
+  {% endfor %}
+</ul>

--- a/_includes/components/content_blocks/text.html
+++ b/_includes/components/content_blocks/text.html
@@ -1,2 +1,2 @@
 {% assign block = include.block %}
-{{ block.title }}
+{{ block.text | markdownify }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,5 +8,7 @@
       {{ content }}
     </main>
     {% include footer.html %}
+
+    {% javascript main %}
   </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -11,7 +11,6 @@ layout: default
 <div class="usa-grid">
   <div class="usa-width-three-fourths">
     <div>
-      {{ page.contentful.content | markdownify }}
       {% include components/content_blocks.html blocks=page.contentful.contentBlocks %}
     </div>
   </div>


### PR DESCRIPTION
This adds support for a new content block type, accordionBlocks, which
is intended to group text blocks into [USWDS accordion lists][uswds].

The accordion component depends on USWDS JS, which is now required in
a main.js included in the default layout. Unlike USWDS Sass, which
we're bundling from source, this includes the bundled/minified JS,
because our build process doesn't currently support commonJS modules.

[uswds]: https://standards.usa.gov/accordions/