### PR TITLE
Implement responsive image gallery and viewer (PhotoSwipe)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'bundler/setup'
 require 'jekyll'
 require 'jekyll-contentful-data-import'
-require './_plugins/mappers/content_block_mapper'
+Dir.glob('./_plugins/mappers/*.rb', &method(:require))
 require './lib/accd/calendar'
 
 desc "Import Contentful data with custom mappers"

--- a/_assets/javascripts/main.js
+++ b/_assets/javascripts/main.js
@@ -1,1 +1,2 @@
 //= require uswds/dist/js/uswds.min.js
+//= require photoswipe

--- a/_assets/javascripts/photoswipe.js
+++ b/_assets/javascripts/photoswipe.js
@@ -1,0 +1,137 @@
+//= require photoswipe/dist/photoswipe.js
+//= require photoswipe/dist/photoswipe-ui-default.js
+
+(function() {
+
+  function handleThumbnailClick(event) {
+    event.preventDefault();
+
+    if (event.target !== event.currentTarget) {
+      var item = event.target;
+
+      while (item.tagName && item.tagName.toLowerCase() !== "figure") {
+        item = item.parentNode;
+      }
+
+      if (item.getAttribute) {
+        var index = parseInt(item.getAttribute("data-index"), 10);
+        openPhotoSwipe(event.currentTarget, index);
+      }
+    }
+  }
+
+  function parseItems(gallery) {
+      var items = [];
+
+      Array.prototype.forEach.call(gallery.children, function(figure, i) {
+        var a = figure.getElementsByTagName("a")[0],
+            caption = figure.getElementsByTagName("figcaption")[0];
+
+        var srcWidth = parseInt(a.getAttribute("data-width"), 10);
+        var srcHeight = parseInt(a.getAttribute("data-height"), 10);
+
+        var item = {
+          url: a.getAttribute("data-url"),
+          width: srcWidth,
+          height: srcHeight,
+          parent: figure,
+          pid: figure.getAttribute("data-pid")
+        };
+
+        if (caption) { item.title = caption.innerHTML; }
+
+        items.push(item);
+      });
+
+      return items;
+  }
+
+  function openPhotoSwipe(gallery, index) {
+    var pswpElement = document.querySelector(".pswp");
+
+    var items = parseItems(gallery);
+
+    var options = {
+      index: index,
+      galleryUID: gallery.getAttribute("data-gid"),
+      galleryPIDs: true,
+      getThumbBoundsFn: false,
+      shareEl: false,
+      showHideOpacity: true
+    };
+
+    var photoswipe = new PhotoSwipe(pswpElement, PhotoSwipeUI_Default, items, options);
+
+    photoswipe.listen("gettingData", function(index, item) {
+      setData(photoswipe, item);
+    });
+
+    photoswipe.init();
+  }
+
+  function setData(photoswipe, item) {
+    var realViewportWidth = photoswipe.viewportSize.x * window.devicePixelRatio,
+        maxWidth;
+
+    if (realViewportWidth > 1900) { // Desktops and retina laptops
+      maxWidth = 2700;
+    } else if (realViewportWidth > 1350) { // Non-retina laptops
+      maxWidth = 1800;
+    } else if (realViewportWidth > 700) { // Newer phones
+      maxWidth = 1200;
+    } else { // Older phones
+      maxWidth = 600;
+    }
+
+    var fit = calculateAspectRatioFit(item.width, item.height, maxWidth, maxWidth);
+
+    item.src = item.url + "?w=" + Math.round(fit.width).toString();
+    item.w = fit.width;
+    item.h = fit.height;
+  }
+
+  function calculateAspectRatioFit(srcWidth, srcHeight, maxWidth, maxHeight) {
+    var ratio = Math.min(maxWidth / srcWidth, maxHeight / srcHeight);
+    return { width: srcWidth * ratio, height: srcHeight * ratio };
+  }
+
+  function initPhotoSwipeFromDOM() {
+    var galleryElements = document.querySelectorAll(".acc-gallery");
+
+    Array.prototype.forEach.call(galleryElements, function (gallery, i) {
+      gallery.addEventListener("click", handleThumbnailClick);
+    });
+  }
+
+  function parseHash() {
+    var hash = location.hash.substring(1),
+        params = {},
+        regex = /([gp]id)=([^&]+)/;
+
+    Array.prototype.forEach.call(hash.split("&"), function(param, i) {
+      var match = param.match(regex);
+      if (match) { params[match[1]] = match[2]; }
+    });
+
+    return params;
+  }
+
+  function openPhotoSwipeFromHash() {
+    var params = parseHash();
+
+    if (params.gid) {
+      var gallery = document.querySelector("div[data-gid='" + params.gid + "']");
+
+      if (gallery) {
+        var figure = params.pid ? gallery.querySelector("figure[data-pid='" + params.pid + "']") : null;
+        openPhotoSwipe(gallery, figure ? parseInt(figure.getAttribute("data-index"), 10) : 0);
+      }
+    }
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+    initPhotoSwipeFromDOM();
+    openPhotoSwipeFromHash();
+  });
+
+})();

--- a/_assets/stylesheets/components/gallery.scss
+++ b/_assets/stylesheets/components/gallery.scss
@@ -1,0 +1,37 @@
+.acc-gallery {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.acc-gallery-photo {
+  max-width: 49%;
+  margin: 0;
+  margin-right: 2%;
+  margin-bottom: 2%;
+}
+
+.acc-gallery-photo:nth-of-type(2n) {
+  margin-right: 0;
+}
+
+@media screen and (min-width: $large-screen) {
+  .acc-gallery-photo, .acc-gallery-photo:nth-of-type(2n) {
+    max-width: 32.666%;
+    margin-right: 1%;
+    margin-bottom: 1%;
+  }
+
+  .acc-gallery-photo:nth-of-type(3n) {
+    margin-right: 0;
+  }
+}
+
+.acc-gallery-photo a {
+  display: block;
+  margin: 0;
+}
+
+.acc-gallery-photo img {
+  display: block;
+  width: 100%;
+}

--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -1,4 +1,6 @@
 //= require ./uswds
+//= require ./vendor/photoswipe
+
 @import "variables/all";
 
 @import "elements/mixins";
@@ -7,6 +9,7 @@
 
 @import "components/breadcrumbs";
 @import "components/footer";
+@import "components/gallery";
 @import "components/header";
 @import "components/sidebar";
 @import "components/homepage";

--- a/_assets/stylesheets/vendor/photoswipe.scss
+++ b/_assets/stylesheets/vendor/photoswipe.scss
@@ -1,0 +1,18 @@
+//= link_directory ../../../node_modules/photoswipe/dist/default-skin
+
+$pswp__assets-path: 'photoswipe/dist/default-skin/';
+
+@import "photoswipe/src/css/main";
+@import "photoswipe/src/css/default-skin/default-skin";
+
+.pswp {
+  z-index: 9999;
+}
+
+.pswp__button {
+  border-radius: 0;
+
+  &:hover {
+    background-color: inherit;
+  }
+}

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ contentful:
         content_types:
           accordionBlock: ContentBlockMapper
           contactBlock: ContentBlockMapper
-          galleryBlock: ContentBlockMapper
+          galleryBlock: GalleryBlockMapper
           menu: ContentBlockMapper
           textBlock: ContentBlockMapper
     # - pec:

--- a/_includes/components/content_blocks.html
+++ b/_includes/components/content_blocks.html
@@ -7,10 +7,12 @@
         {% when "contactBlock" %}
           {% include components/content_blocks/contact.html block=block %}
         {% when "galleryBlock" %}
+          {% assign photoswipe = true %}
           {% include components/content_blocks/gallery.html block=block %}
         {% when "textBlock" %}
           {% include components/content_blocks/text.html block=block %}
       {% endcase %}
     {% endfor %}
   </div>
+  {% if photoswipe %}{% include components/photoswipe.html %}{% endif %}
 {% endif %}

--- a/_includes/components/content_blocks/gallery.html
+++ b/_includes/components/content_blocks/gallery.html
@@ -1,2 +1,20 @@
 {% assign block = include.block %}
-{{ block.title }}
+
+<h2>{{ block.title }}</h2>
+
+<div itemscope itemtype="http://schema.org/ImageGallery" data-gid="{{ block.sys.id }}" class="acc-gallery">
+  {% for image in block.images %}
+    <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject" data-index="{{ forloop.index0 }}" data-pid="{{ image.sys.id }}" class="acc-gallery-photo">
+      <a href="{{ image.url }}?w=1800" itemprop="contentUrl" data-width="{{ image.width }}" data-height="{{ image.height }}" data-url="{{ image.url }}">
+        <img src="{{ image.url }}?w=330&h=220&fit=thumb"
+          srcset="{{ image.url }}?w=990&h=660&fit=thumb 3x,
+                  {{ image.url }}?w=660&h=440&fit=thumb 2x,
+                  {{ image.url }}?w=330&h=220&fit=thumb"
+          itemprop="thumbnail" alt="{{ image.title }}" />
+      </a>
+      {% if image.description %}
+        <figcaption itemprop="caption description">{{ image.description }}</figcaption>
+      {% endif %}
+    </figure>
+  {% endfor %}
+</div>

--- a/_includes/components/photoswipe.html
+++ b/_includes/components/photoswipe.html
@@ -1,0 +1,66 @@
+<!-- Root element of PhotoSwipe. Must have class pswp. -->
+<div class="pswp" tabindex="-1" role="dialog" aria-hidden="true">
+
+    <!-- Background of PhotoSwipe.
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+
+        <!-- Container that holds slides.
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <!--  Controls are self-explanatory. Order can be changed. -->
+
+                <div class="pswp__counter"></div>
+
+                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+
+                <button class="pswp__button pswp__button--share" title="Share"></button>
+
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+
+                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+
+                <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
+                <!-- element will get class pswp__preloader--active when preloader is running -->
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                      <div class="pswp__preloader__cut">
+                        <div class="pswp__preloader__donut"></div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+            </button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+            </button>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+
+        </div>
+
+    </div>
+
+</div>

--- a/_plugins/mappers/gallery_block_mapper.rb
+++ b/_plugins/mappers/gallery_block_mapper.rb
@@ -1,0 +1,17 @@
+require_relative "content_block_mapper"
+
+class GalleryBlockMapper < ContentBlockMapper
+
+  # Add ID and image dimensions to gallery block images
+  def map_asset(asset)
+    result = super
+    result["sys"] = { "id" => asset.sys[:id] }
+
+    if asset.file.details.key?("image")
+      result.merge!(asset.file.details["image"])
+    end
+
+    result
+  end
+
+end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "austinconventioncenter.com",
   "dependencies": {
+    "photoswipe": "^4.1.1",
     "uswds": "^0.13.1"
   }
 }


### PR DESCRIPTION
Gallery blocks now render as responsive grid of thumbnails cropped to
a 3:2 aspect ratio, and display in full (also responsive) sizes in
PhotoSwipe (photoswipe.com).

I picked PhotoSwipe from GitHub, where (by my estimation) it's the
most popular JS image viewer by far (12k+ stars). It has solid
documentation and an active community, and fairly extensive options
for customizing both the appearance and behavior. It's completely
markup-agnostic, which means we can use Schema.org's ImageGallery
markup.

The new JS file here is based on PhotoSwipe's example code, but
it doesn't bother with IE8 compatability and has a couple notable
differences:

* The responsive image sizing uses Contentful's Images API. Since
  PhotoSwipe needs the dimensions among its options, we calculate
  them based on the original image's dimensions, which are output by
  the new GalleryBlockMapper and rendered as data- attributes.

* It uses Contentful IDs for the gallery ID and picture ID that
  PhotoSwipe sets in the URL hash, which means that permalinks should
  still work regardless of the order of gallery blocks and images
  within them.

The responsive thumbnail grid uses flexbox and shows either 2 or 3
images per row depending on the viewport. I spent a lot of time
trying different flexbox options; my original hope was to crop the
thumbnails in CSS so that we could enable PhotoSwipe's nice
transition animation using the uncropped thumbnail. In theory, we'd
want to say that a thumbnail is 33% wide and has a height of 2/3rds
of that, hiding the overflow, but percentage heights are sort of a
joke; CSS ignores them unless the parent has a fixed height.

Thus flexbox loves to render each row at the height of the tallest
thumbnail. I *could* set a best-guess max-height in pixels, but that
changes the aspect ratio of the thumbnails as the viewport scales,
and the transition animation looks almost as janky as starting with a
pre-cropped thumbnail. I eventually just gave up, cropped the
thumbnails via the Contentful API, and disabled the animation.

The flexbox styles are fairly straightforward, the only maybe-unusual
part is the nth-of-type declarations. Flexbox's justify-content rule
doesn't work well if rows don't have the same number of items, so
those are needed to have edge-to-edge rows with the last row aligned
left.

The only additional gallery feature that I think we might want to add
would be limiting the number of thumbnails displayed, and having a
"View All" button open PhotoSwipe if there are more than the limit.
Whether that makes sense depends a lot on how many photos there end
up being, so we can wait and add it later.