### PR TITLE
Fix Flexbox-related bugs affecting Safari and Firefox

### DIFF
--- a/_assets/stylesheets/components/gallery.scss
+++ b/_assets/stylesheets/components/gallery.scss
@@ -1,13 +1,14 @@
 .acc-gallery {
   display: flex;
+  flex: 0 1 auto;
   flex-wrap: wrap;
 }
 
 .acc-gallery-photo {
-  max-width: 49%;
+  width: calc((100% - 0.5em)/2); // 0.5em gutter
   margin: 0;
-  margin-right: 2%;
-  margin-bottom: 2%;
+  margin-right: 0.5em;
+  margin-bottom: 0.5em;
 }
 
 .acc-gallery-photo:nth-of-type(2n) {
@@ -15,10 +16,12 @@
 }
 
 @media screen and (min-width: $large-screen) {
-  .acc-gallery-photo, .acc-gallery-photo:nth-of-type(2n) {
-    max-width: 32.666%;
-    margin-right: 1%;
-    margin-bottom: 1%;
+  .acc-gallery-photo {
+    width: calc((100% - 1em)/3); // 0.5em gutter x 2
+  }
+
+  .acc-gallery-photo:nth-of-type(2n) {
+    margin-right: 0.5em;
   }
 
   .acc-gallery-photo:nth-of-type(3n) {


### PR DESCRIPTION
1. Safari doesn't play nicely with max-width (see
   [philipwalton/flexbugs #11]), so this switches to width.

2. Firefox doesn't render percentage bottom-margins on flex items,
   which is apparently not a bug but the correct behavior, so this
   switches to ems for the margins, and consequently calc for the
   widths.

Haven't yet tested this layout in IE so more fun may be yet to come.

[philipwalton/flexbugs #11]: https://github.com/philipwalton/flexbugs#11-min-and-max-size-declarations-are-ignored-when-wrapping-flex-items