### PR TITLE
Force press release page breadcrumb to show date instead of title

### DIFF
--- a/_layouts/press_release.html
+++ b/_layouts/press_release.html
@@ -2,12 +2,6 @@
 layout: default
 ---
 
-<style type="text/css">
-  .acc-breadcrumb:last-child {
-    display: none;
-  }
-</style>
-
 <div class="usa-grid">
   <div class="usa-width-three-fourths">
     <h1 class="acc-press-headline">{{ page.contentful.title }}</h1>

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -33,7 +33,8 @@ module Jekyll
 
       data["pressRelease"].each do |attributes|
         attributes["date"] = attributes["date"].utc # Undo implicit time zone conversion
-        generate_page(site, site.collections["press-releases"], attributes)
+        page = generate_page(site, site.collections["press-releases"], attributes)
+        page.data["breadcrumbs"][-1]["title"] = attributes["date"].strftime("%B %-d, %Y")
       end
     end
 


### PR DESCRIPTION
Since the titles tend to be very long.