### PR TITLE
Ensure a division contact page exists before linking to it

### DIFF
--- a/_includes/components/sidebar_blocks/contact.html
+++ b/_includes/components/sidebar_blocks/contact.html
@@ -12,12 +12,16 @@
       {{ contact.phone | format_phone }}
     </p>
   {% endif %}
-    <p class="acc-email-link">
-      <a href="mailto:{{ contact.email }}" class="acc-sidebar-email-link">{{ contact.email }}</a>
-    </p>
-  {% if contact.division != blank %}
-    <p>
-        <a class="acc-button acc-button-dark" href="{{ site.baseurl }}/contact/{{contact.division | slugify }}">{{ contact.division }} Team</a>
-    </p>
+  <p class="acc-email-link">
+    <a href="mailto:{{ contact.email }}" class="acc-sidebar-email-link">{{ contact.email }}</a>
+  </p>
+  {% if contact.division %}
+    {% capture contact_url %}/contact/{{ contact.division | slugify }}/{% endcapture %}
+    {% assign contact_page = site.pages | where: "url", contact_url | first %}
+    {% if contact_page %}
+      <p>
+        <a class="acc-button acc-button-dark" href="{{ contact_page.url }}">{{ contact.division }} Team</a>
+      </p>
+    {% endif %}
   {% endif %}
 </div>


### PR DESCRIPTION
Sidebar contact blocks attempt to infer a division contact page from
the Division contact attribute (which comes from a set predefined in
Contentful); this simply makes it so that we don't generate a broken
link if the page doesn't exist.