### PR TITLE
Convert floor plan maps to interactive SVGs

### DIFF
--- a/_assets/images/floor-plan-overview.svg
+++ b/_assets/images/floor-plan-overview.svg
@@ -1,0 +1,5003 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 590.2 358.6" enable-background="new 0 0 590.2 358.6" xml:space="preserve">
+<g id="XMLID_475_">
+	<g id="XMLID_476_" enable-background="new    ">
+		<g id="XMLID_825_" enable-background="new    ">
+			<defs>
+				<polygon id="XMLID_826_" enable-background="new    " points="225.7,235.7 223,238.1 233.4,238 236,235.7 252.7,235.5 
+					250.1,237.8 223.7,262.4 264.9,262.2 254.9,271.9 329.3,271.7 355.3,243.6 389.6,243.3 395.7,236.3 435.7,235.9 433.5,238.6 
+					436.5,238.9 438.2,241.4 436.4,245.8 431.6,249 436.4,252.8 442.7,254.3 447.4,257.4 462.2,257.6 474.9,261.4 491.4,261.3 
+					508,260.5 513,263.1 540.5,265.4 555.8,271.5 551.3,278.8 559.9,278.8 566.4,280.2 570.2,282.8 568.4,285.8 561.6,288.8 
+					552.3,290.1 549.2,295.2 544.3,295.2 535.9,308.4 527.5,308.4 514.8,328.7 513.8,330.6 520.9,330.7 517.5,336.3 534.5,336.5 
+					529.1,345.6 522.7,358.6 475,358 475.4,357.3 450.4,357 441.6,356.3 445.1,351.2 377.8,350.5 374.3,355 359.3,354.9 358,356.6 
+					331.5,356.3 333.2,354.1 325.1,354 326.6,352.2 318,352.1 319.3,350.5 267.8,347.1 270.2,344.8 213.7,344.2 211.6,346.3 
+					187.4,346.1 187.9,345.5 179.5,345.4 177.4,347.4 168.1,347.3 161,354.1 137.3,353.8 144.6,347 132.2,346.9 126.5,352.1 
+					101.1,351.8 106.9,346.6 69.1,346.1 49.6,345.8 45,349.6 28.8,349.5 33.4,345.6 36.2,343.4 27.3,343.3 25.9,344.4 17.7,344.3 
+					16,345.7 6.3,345.6 8,344.2 0,344.1 34.9,316.4 45.6,316.4 53.8,309.8 39.9,309.8 47.6,303.7 56.1,303.7 62.8,298.3 56.1,298.3 
+					58.2,296.6 71.5,285.5 74.1,284 80.7,284 87.2,278.8 79.2,278.8 86.1,273.3 94.1,273.3 119.1,253.3 133.9,253.2 123.4,253.2 
+					135.1,243.9 138.2,243.9 143.8,239.4 148.5,239.3 152.1,236.5 				"/>
+			</defs>
+			<use xlink:href="#XMLID_826_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_131_">
+				<use xlink:href="#XMLID_826_"  overflow="visible"/>
+			</clipPath>
+			<polygon id="XMLID_827_" clip-path="url(#XMLID_131_)" fill="#F5F4F8" points="225.7,235.7 223,238.1 233.4,238 236,235.7 
+				252.7,235.5 250.1,237.8 223.7,262.4 264.9,262.2 254.9,271.9 329.3,271.7 355.3,243.6 389.6,243.3 395.7,236.3 435.7,235.9 
+				433.5,238.6 436.5,238.9 438.2,241.4 436.4,245.8 431.6,249 436.4,252.8 442.7,254.3 447.4,257.4 462.2,257.6 474.9,261.4 
+				491.4,261.3 508,260.5 513,263.1 540.5,265.4 555.8,271.5 551.3,278.8 559.9,278.8 566.4,280.2 570.2,282.8 568.4,285.8 
+				561.6,288.8 552.3,290.1 549.2,295.2 544.3,295.2 535.9,308.4 527.5,308.4 514.8,328.7 513.8,330.6 520.9,330.7 517.5,336.3 
+				534.5,336.5 529.1,345.6 522.7,358.6 475,358 475.4,357.3 450.4,357 441.6,356.3 445.1,351.2 377.8,350.5 374.3,355 359.3,354.9 
+				358,356.6 331.5,356.3 333.2,354.1 325.1,354 326.6,352.2 318,352.1 319.3,350.5 267.8,347.1 270.2,344.8 213.7,344.2 
+				211.6,346.3 187.4,346.1 187.9,345.5 179.5,345.4 177.4,347.4 168.1,347.3 161,354.1 137.3,353.8 144.6,347 132.2,346.9 
+				126.5,352.1 101.1,351.8 106.9,346.6 69.1,346.1 49.6,345.8 45,349.6 28.8,349.5 33.4,345.6 36.2,343.4 27.3,343.3 25.9,344.4 
+				17.7,344.3 16,345.7 6.3,345.6 8,344.2 0,344.1 34.9,316.4 45.6,316.4 53.8,309.8 39.9,309.8 47.6,303.7 56.1,303.7 62.8,298.3 
+				56.1,298.3 58.2,296.6 71.5,285.5 74.1,284 80.7,284 87.2,278.8 79.2,278.8 86.1,273.3 94.1,273.3 119.1,253.3 133.9,253.2 
+				123.4,253.2 135.1,243.9 138.2,243.9 143.8,239.4 148.5,239.3 152.1,236.5 			"/>
+		</g>
+		<g id="XMLID_822_" enable-background="new    ">
+			<defs>
+				<polygon id="XMLID_823_" enable-background="new    " points="225.7,235.7 223,238.1 233.4,238 236,235.7 252.7,235.5 
+					250.1,237.8 223.7,262.4 264.9,262.2 254.9,271.9 329.3,271.7 355.3,243.6 389.6,243.3 395.7,236.3 435.7,235.9 433.5,238.6 
+					436.5,238.9 438.2,241.4 436.4,245.8 431.6,249 436.4,252.8 442.7,254.3 447.4,257.4 462.2,257.6 474.9,261.4 491.4,261.3 
+					508,260.5 513,263.1 540.5,265.4 555.8,271.5 551.3,278.8 559.9,278.8 566.4,280.2 570.2,282.8 568.4,285.8 561.6,288.8 
+					552.3,290.1 549.2,295.2 544.3,295.2 535.9,308.4 527.5,308.4 514.8,328.7 513.8,330.6 520.9,330.7 517.5,336.3 534.5,336.5 
+					529.1,345.6 522.7,358.6 475,358 475.4,357.3 450.4,357 441.6,356.3 445.1,351.2 377.8,350.5 374.3,355 359.3,354.9 358,356.6 
+					331.5,356.3 333.2,354.1 325.1,354 326.6,352.2 318,352.1 319.3,350.5 267.8,347.1 270.2,344.8 213.7,344.2 211.6,346.3 
+					187.4,346.1 187.9,345.5 179.5,345.4 177.4,347.4 168.1,347.3 161,354.1 137.3,353.8 144.6,347 132.2,346.9 126.5,352.1 
+					101.1,351.8 106.9,346.6 69.1,346.1 49.6,345.8 45,349.6 28.8,349.5 33.4,345.6 36.2,343.4 27.3,343.3 25.9,344.4 17.7,344.3 
+					16,345.7 6.3,345.6 8,344.2 0,344.1 34.9,316.4 45.6,316.4 53.8,309.8 39.9,309.8 47.6,303.7 56.1,303.7 62.8,298.3 56.1,298.3 
+					58.2,296.6 71.5,285.5 74.1,284 80.7,284 87.2,278.8 79.2,278.8 86.1,273.3 94.1,273.3 119.1,253.3 133.9,253.2 123.4,253.2 
+					135.1,243.9 138.2,243.9 143.8,239.4 148.5,239.3 152.1,236.5 				"/>
+			</defs>
+			<use xlink:href="#XMLID_823_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_137_">
+				<use xlink:href="#XMLID_823_"  overflow="visible"/>
+			</clipPath>
+			<polygon id="XMLID_824_" clip-path="url(#XMLID_137_)" fill="#F5F4F8" points="225.7,235.7 223,238.1 233.4,238 236,235.7 
+				252.7,235.5 250.1,237.8 223.7,262.4 264.9,262.2 254.9,271.9 329.3,271.7 355.3,243.6 389.6,243.3 395.7,236.3 435.7,235.9 
+				433.5,238.6 436.5,238.9 438.2,241.4 436.4,245.8 431.6,249 436.4,252.8 442.7,254.3 447.4,257.4 462.2,257.6 474.9,261.4 
+				491.4,261.3 508,260.5 513,263.1 540.5,265.4 555.8,271.5 551.3,278.8 559.9,278.8 566.4,280.2 570.2,282.8 568.4,285.8 
+				561.6,288.8 552.3,290.1 549.2,295.2 544.3,295.2 535.9,308.4 527.5,308.4 514.8,328.7 513.8,330.6 520.9,330.7 517.5,336.3 
+				534.5,336.5 529.1,345.6 522.7,358.6 475,358 475.4,357.3 450.4,357 441.6,356.3 445.1,351.2 377.8,350.5 374.3,355 359.3,354.9 
+				358,356.6 331.5,356.3 333.2,354.1 325.1,354 326.6,352.2 318,352.1 319.3,350.5 267.8,347.1 270.2,344.8 213.7,344.2 
+				211.6,346.3 187.4,346.1 187.9,345.5 179.5,345.4 177.4,347.4 168.1,347.3 161,354.1 137.3,353.8 144.6,347 132.2,346.9 
+				126.5,352.1 101.1,351.8 106.9,346.6 69.1,346.1 49.6,345.8 45,349.6 28.8,349.5 33.4,345.6 36.2,343.4 27.3,343.3 25.9,344.4 
+				17.7,344.3 16,345.7 6.3,345.6 8,344.2 0,344.1 34.9,316.4 45.6,316.4 53.8,309.8 39.9,309.8 47.6,303.7 56.1,303.7 62.8,298.3 
+				56.1,298.3 58.2,296.6 71.5,285.5 74.1,284 80.7,284 87.2,278.8 79.2,278.8 86.1,273.3 94.1,273.3 119.1,253.3 133.9,253.2 
+				123.4,253.2 135.1,243.9 138.2,243.9 143.8,239.4 148.5,239.3 152.1,236.5 			"/>
+		</g>
+		<g id="XMLID_819_">
+			<defs>
+				<path id="XMLID_820_" d="M225.7,235.7l-2.7,2.4L225.7,235.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_820_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_138_">
+				<use xlink:href="#XMLID_820_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_821_" clip-path="url(#XMLID_138_)" fill="#F5F4F8" d="M225.7,235.7l-2.7,2.4L225.7,235.7z"/>
+		</g>
+		<g id="XMLID_816_">
+			<defs>
+				<path id="XMLID_817_" d="M223,238.1l10.4-0.1L223,238.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_817_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_139_">
+				<use xlink:href="#XMLID_817_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_818_" clip-path="url(#XMLID_139_)" fill="#F5F4F8" d="M223,238.1l10.4-0.1L223,238.1z"/>
+		</g>
+		<g id="XMLID_813_">
+			<defs>
+				<path id="XMLID_814_" d="M233.4,238l2.6-2.3L233.4,238z"/>
+			</defs>
+			<use xlink:href="#XMLID_814_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_140_">
+				<use xlink:href="#XMLID_814_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_815_" clip-path="url(#XMLID_140_)" fill="#F5F4F8" d="M233.4,238l2.6-2.3L233.4,238z"/>
+		</g>
+		<g id="XMLID_810_">
+			<defs>
+				<path id="XMLID_811_" d="M236,235.7l16.6-0.2L236,235.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_811_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_142_">
+				<use xlink:href="#XMLID_811_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_812_" clip-path="url(#XMLID_142_)" fill="#F5F4F8" d="M236,235.7l16.6-0.2L236,235.7z"/>
+		</g>
+		<g id="XMLID_807_">
+			<defs>
+				<path id="XMLID_808_" d="M252.7,235.5l-2.5,2.3L252.7,235.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_808_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_144_">
+				<use xlink:href="#XMLID_808_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_809_" clip-path="url(#XMLID_144_)" fill="#F5F4F8" d="M252.7,235.5l-2.5,2.3L252.7,235.5z"/>
+		</g>
+		<g id="XMLID_804_">
+			<defs>
+				<path id="XMLID_805_" d="M250.1,237.8l-26.5,24.6L250.1,237.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_805_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_145_">
+				<use xlink:href="#XMLID_805_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_806_" clip-path="url(#XMLID_145_)" fill="#F5F4F8" d="M250.1,237.8l-26.5,24.6L250.1,237.8z"/>
+		</g>
+		<g id="XMLID_801_">
+			<defs>
+				<path id="XMLID_802_" d="M223.7,262.4l41.3-0.2L223.7,262.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_802_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_147_">
+				<use xlink:href="#XMLID_802_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_803_" clip-path="url(#XMLID_147_)" fill="#F5F4F8" d="M223.7,262.4l41.3-0.2L223.7,262.4z"/>
+		</g>
+		<g id="XMLID_798_">
+			<defs>
+				<path id="XMLID_799_" d="M264.9,262.2l-10,9.7L264.9,262.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_799_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_148_">
+				<use xlink:href="#XMLID_799_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_800_" clip-path="url(#XMLID_148_)" fill="#F5F4F8" d="M264.9,262.2l-10,9.7L264.9,262.2z"/>
+		</g>
+		<g id="XMLID_795_">
+			<defs>
+				<path id="XMLID_796_" d="M254.9,271.9l74.4-0.3L254.9,271.9z"/>
+			</defs>
+			<use xlink:href="#XMLID_796_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_149_">
+				<use xlink:href="#XMLID_796_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_797_" clip-path="url(#XMLID_149_)" fill="#F5F4F8" d="M254.9,271.9l74.4-0.3L254.9,271.9z"/>
+		</g>
+		<g id="XMLID_792_">
+			<defs>
+				<path id="XMLID_793_" d="M329.3,271.7l26-28L329.3,271.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_793_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_150_">
+				<use xlink:href="#XMLID_793_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_794_" clip-path="url(#XMLID_150_)" fill="#F5F4F8" d="M329.3,271.7l26-28L329.3,271.7z"/>
+		</g>
+		<g id="XMLID_789_">
+			<defs>
+				<path id="XMLID_790_" d="M355.3,243.6l34.3-0.3L355.3,243.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_790_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_152_">
+				<use xlink:href="#XMLID_790_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_791_" clip-path="url(#XMLID_152_)" fill="#F5F4F8" d="M355.3,243.6l34.3-0.3L355.3,243.6z"/>
+		</g>
+		<g id="XMLID_786_">
+			<defs>
+				<path id="XMLID_787_" d="M389.6,243.3l6.2-7L389.6,243.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_787_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_153_">
+				<use xlink:href="#XMLID_787_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_788_" clip-path="url(#XMLID_153_)" fill="#F5F4F8" d="M389.6,243.3l6.2-7L389.6,243.3z"/>
+		</g>
+		<g id="XMLID_783_">
+			<defs>
+				<path id="XMLID_784_" d="M395.7,236.3l40-0.4L395.7,236.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_784_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_154_">
+				<use xlink:href="#XMLID_784_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_785_" clip-path="url(#XMLID_154_)" fill="#F5F4F8" d="M395.7,236.3l40-0.4L395.7,236.3z"/>
+		</g>
+		<g id="XMLID_780_">
+			<defs>
+				<path id="XMLID_781_" d="M435.7,235.9l-2.2,2.7L435.7,235.9z"/>
+			</defs>
+			<use xlink:href="#XMLID_781_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_155_">
+				<use xlink:href="#XMLID_781_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_782_" clip-path="url(#XMLID_155_)" fill="#F5F4F8" d="M435.7,235.9l-2.2,2.7L435.7,235.9z"/>
+		</g>
+		<g id="XMLID_777_">
+			<defs>
+				<path id="XMLID_778_" d="M433.5,238.6l3,0.3L433.5,238.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_778_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_157_">
+				<use xlink:href="#XMLID_778_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_779_" clip-path="url(#XMLID_157_)" fill="#F5F4F8" d="M433.5,238.6l3,0.3L433.5,238.6z"/>
+		</g>
+		<g id="XMLID_774_">
+			<defs>
+				<path id="XMLID_775_" d="M436.5,238.9l1.7,2.5L436.5,238.9z"/>
+			</defs>
+			<use xlink:href="#XMLID_775_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_159_">
+				<use xlink:href="#XMLID_775_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_776_" clip-path="url(#XMLID_159_)" fill="#F5F4F8" d="M436.5,238.9l1.7,2.5L436.5,238.9z"/>
+		</g>
+		<g id="XMLID_771_">
+			<defs>
+				<path id="XMLID_772_" d="M438.2,241.4l-1.8,4.4L438.2,241.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_772_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_160_">
+				<use xlink:href="#XMLID_772_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_773_" clip-path="url(#XMLID_160_)" fill="#F5F4F8" d="M438.2,241.4l-1.8,4.4L438.2,241.4z"/>
+		</g>
+		<g id="XMLID_768_">
+			<defs>
+				<path id="XMLID_769_" d="M436.4,245.8l-4.8,3.2L436.4,245.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_769_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_161_">
+				<use xlink:href="#XMLID_769_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_770_" clip-path="url(#XMLID_161_)" fill="#F5F4F8" d="M436.4,245.8l-4.8,3.2L436.4,245.8z"/>
+		</g>
+		<g id="XMLID_765_">
+			<defs>
+				<path id="XMLID_766_" d="M431.6,249l4.8,3.7L431.6,249z"/>
+			</defs>
+			<use xlink:href="#XMLID_766_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_162_">
+				<use xlink:href="#XMLID_766_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_767_" clip-path="url(#XMLID_162_)" fill="#F5F4F8" d="M431.6,249l4.8,3.7L431.6,249z"/>
+		</g>
+		<g id="XMLID_762_">
+			<defs>
+				<path id="XMLID_763_" d="M436.4,252.8l6.3,1.5L436.4,252.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_763_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_164_">
+				<use xlink:href="#XMLID_763_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_764_" clip-path="url(#XMLID_164_)" fill="#F5F4F8" d="M436.4,252.8l6.3,1.5L436.4,252.8z"/>
+		</g>
+		<g id="XMLID_759_">
+			<defs>
+				<path id="XMLID_760_" d="M442.7,254.3l4.6,3.1L442.7,254.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_760_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_165_">
+				<use xlink:href="#XMLID_760_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_761_" clip-path="url(#XMLID_165_)" fill="#F5F4F8" d="M442.7,254.3l4.6,3.1L442.7,254.3z"/>
+		</g>
+		<g id="XMLID_756_">
+			<defs>
+				<path id="XMLID_757_" d="M447.4,257.4l14.8,0.2L447.4,257.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_757_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_166_">
+				<use xlink:href="#XMLID_757_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_758_" clip-path="url(#XMLID_166_)" fill="#F5F4F8" d="M447.4,257.4l14.8,0.2L447.4,257.4z"/>
+		</g>
+		<g id="XMLID_753_">
+			<defs>
+				<path id="XMLID_754_" d="M462.2,257.6l12.7,3.8L462.2,257.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_754_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_167_">
+				<use xlink:href="#XMLID_754_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_755_" clip-path="url(#XMLID_167_)" fill="#F5F4F8" d="M462.2,257.6l12.7,3.8L462.2,257.6z"/>
+		</g>
+		<g id="XMLID_750_">
+			<defs>
+				<path id="XMLID_751_" d="M474.9,261.4l16.5-0.1L474.9,261.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_751_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_169_">
+				<use xlink:href="#XMLID_751_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_752_" clip-path="url(#XMLID_169_)" fill="#F5F4F8" d="M474.9,261.4l16.5-0.1L474.9,261.4z"/>
+		</g>
+		<g id="XMLID_747_">
+			<defs>
+				<path id="XMLID_748_" d="M491.4,261.3l16.5-0.8L491.4,261.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_748_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_170_">
+				<use xlink:href="#XMLID_748_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_749_" clip-path="url(#XMLID_170_)" fill="#F5F4F8" d="M491.4,261.3l16.5-0.8L491.4,261.3z"/>
+		</g>
+		<g id="XMLID_744_">
+			<defs>
+				<path id="XMLID_745_" d="M508,260.5l5,2.6L508,260.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_745_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_171_">
+				<use xlink:href="#XMLID_745_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_746_" clip-path="url(#XMLID_171_)" fill="#F5F4F8" d="M508,260.5l5,2.6L508,260.5z"/>
+		</g>
+		<g id="XMLID_741_">
+			<defs>
+				<path id="XMLID_742_" d="M513,263.1l27.5,2.2L513,263.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_742_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_172_">
+				<use xlink:href="#XMLID_742_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_743_" clip-path="url(#XMLID_172_)" fill="#F5F4F8" d="M513,263.1l27.5,2.2L513,263.1z"/>
+		</g>
+		<g id="XMLID_738_">
+			<defs>
+				<path id="XMLID_739_" d="M540.5,265.4l15.3,6.2L540.5,265.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_739_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_173_">
+				<use xlink:href="#XMLID_739_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_740_" clip-path="url(#XMLID_173_)" fill="#F5F4F8" d="M540.5,265.4l15.3,6.2L540.5,265.4z"/>
+		</g>
+		<g id="XMLID_735_">
+			<defs>
+				<path id="XMLID_736_" d="M555.8,271.5l-4.5,7.3L555.8,271.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_736_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_175_">
+				<use xlink:href="#XMLID_736_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_737_" clip-path="url(#XMLID_175_)" fill="#F5F4F8" d="M555.8,271.5l-4.5,7.3L555.8,271.5z"/>
+		</g>
+		<g id="XMLID_732_">
+			<defs>
+				<path id="XMLID_733_" d="M551.3,278.8l8.6,0L551.3,278.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_733_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_176_">
+				<use xlink:href="#XMLID_733_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_734_" clip-path="url(#XMLID_176_)" fill="#F5F4F8" d="M551.3,278.8l8.6,0L551.3,278.8z"/>
+		</g>
+		<g id="XMLID_729_">
+			<defs>
+				<path id="XMLID_730_" d="M559.9,278.8l6.5,1.4L559.9,278.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_730_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_177_">
+				<use xlink:href="#XMLID_730_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_731_" clip-path="url(#XMLID_177_)" fill="#F5F4F8" d="M559.9,278.8l6.5,1.4L559.9,278.8z"/>
+		</g>
+		<g id="XMLID_726_">
+			<defs>
+				<path id="XMLID_727_" d="M566.4,280.2l3.8,2.6L566.4,280.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_727_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_178_">
+				<use xlink:href="#XMLID_727_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_728_" clip-path="url(#XMLID_178_)" fill="#F5F4F8" d="M566.4,280.2l3.8,2.6L566.4,280.2z"/>
+		</g>
+		<g id="XMLID_723_">
+			<defs>
+				<path id="XMLID_724_" d="M570.2,282.8l-1.8,3L570.2,282.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_724_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_180_">
+				<use xlink:href="#XMLID_724_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_725_" clip-path="url(#XMLID_180_)" fill="#F5F4F8" d="M570.2,282.8l-1.8,3L570.2,282.8z"/>
+		</g>
+		<g id="XMLID_720_">
+			<defs>
+				<path id="XMLID_721_" d="M568.4,285.8l-6.8,3L568.4,285.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_721_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_181_">
+				<use xlink:href="#XMLID_721_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_722_" clip-path="url(#XMLID_181_)" fill="#F5F4F8" d="M568.4,285.8l-6.8,3L568.4,285.8z"/>
+		</g>
+		<g id="XMLID_717_">
+			<defs>
+				<path id="XMLID_718_" d="M561.6,288.8l-9.3,1.3L561.6,288.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_718_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_182_">
+				<use xlink:href="#XMLID_718_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_719_" clip-path="url(#XMLID_182_)" fill="#F5F4F8" d="M561.6,288.8l-9.3,1.3L561.6,288.8z"/>
+		</g>
+		<g id="XMLID_714_">
+			<defs>
+				<path id="XMLID_715_" d="M552.3,290.1l-3.1,5.1L552.3,290.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_715_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_183_">
+				<use xlink:href="#XMLID_715_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_716_" clip-path="url(#XMLID_183_)" fill="#F5F4F8" d="M552.3,290.1l-3.1,5.1L552.3,290.1z"/>
+		</g>
+		<g id="XMLID_711_">
+			<defs>
+				<path id="XMLID_712_" d="M549.2,295.2l-4.9,0L549.2,295.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_712_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_185_">
+				<use xlink:href="#XMLID_712_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_713_" clip-path="url(#XMLID_185_)" fill="#F5F4F8" d="M549.2,295.2l-4.9,0L549.2,295.2z"/>
+		</g>
+		<g id="XMLID_708_">
+			<defs>
+				<path id="XMLID_709_" d="M544.3,295.2l-8.5,13.2L544.3,295.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_709_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_186_">
+				<use xlink:href="#XMLID_709_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_710_" clip-path="url(#XMLID_186_)" fill="#F5F4F8" d="M544.3,295.2l-8.5,13.2L544.3,295.2z"/>
+		</g>
+		<g id="XMLID_705_">
+			<defs>
+				<path id="XMLID_706_" d="M535.9,308.4l-8.4,0L535.9,308.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_706_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_187_">
+				<use xlink:href="#XMLID_706_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_707_" clip-path="url(#XMLID_187_)" fill="#F5F4F8" d="M535.9,308.4l-8.4,0L535.9,308.4z"/>
+		</g>
+		<g id="XMLID_702_">
+			<defs>
+				<path id="XMLID_703_" d="M527.5,308.4l-12.6,20.4L527.5,308.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_703_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_188_">
+				<use xlink:href="#XMLID_703_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_704_" clip-path="url(#XMLID_188_)" fill="#F5F4F8" d="M527.5,308.4l-12.6,20.4L527.5,308.4z"/>
+		</g>
+		<g id="XMLID_699_">
+			<defs>
+				<path id="XMLID_700_" d="M514.8,328.7l-1,1.9L514.8,328.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_700_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_189_">
+				<use xlink:href="#XMLID_700_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_701_" clip-path="url(#XMLID_189_)" fill="#F5F4F8" d="M514.8,328.7l-1,1.9L514.8,328.7z"/>
+		</g>
+		<g id="XMLID_696_">
+			<defs>
+				<path id="XMLID_697_" d="M513.8,330.6l7.1,0.1L513.8,330.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_697_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_191_">
+				<use xlink:href="#XMLID_697_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_698_" clip-path="url(#XMLID_191_)" fill="#F5F4F8" d="M513.8,330.6l7.1,0.1L513.8,330.6z"/>
+		</g>
+		<g id="XMLID_693_">
+			<defs>
+				<path id="XMLID_694_" d="M520.9,330.7l-3.4,5.6L520.9,330.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_694_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_192_">
+				<use xlink:href="#XMLID_694_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_695_" clip-path="url(#XMLID_192_)" fill="#F5F4F8" d="M520.9,330.7l-3.4,5.6L520.9,330.7z"/>
+		</g>
+		<g id="XMLID_690_">
+			<defs>
+				<path id="XMLID_691_" d="M517.5,336.3l17,0.1L517.5,336.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_691_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_193_">
+				<use xlink:href="#XMLID_691_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_692_" clip-path="url(#XMLID_193_)" fill="#F5F4F8" d="M517.5,336.3l17,0.1L517.5,336.3z"/>
+		</g>
+		<g id="XMLID_687_">
+			<defs>
+				<path id="XMLID_688_" d="M534.5,336.5l-5.4,9.2L534.5,336.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_688_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_194_">
+				<use xlink:href="#XMLID_688_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_689_" clip-path="url(#XMLID_194_)" fill="#F5F4F8" d="M534.5,336.5l-5.4,9.2L534.5,336.5z"/>
+		</g>
+		<g id="XMLID_684_">
+			<defs>
+				<path id="XMLID_685_" d="M529.1,345.6l-6.4,13L529.1,345.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_685_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_196_">
+				<use xlink:href="#XMLID_685_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_686_" clip-path="url(#XMLID_196_)" fill="#F5F4F8" d="M529.1,345.6l-6.4,13L529.1,345.6z"/>
+		</g>
+		<g id="XMLID_681_">
+			<defs>
+				<path id="XMLID_682_" d="M522.7,358.6L475,358L522.7,358.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_682_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_197_">
+				<use xlink:href="#XMLID_682_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_683_" clip-path="url(#XMLID_197_)" fill="#F5F4F8" d="M522.7,358.6L475,358L522.7,358.6z"/>
+		</g>
+		<g id="XMLID_678_">
+			<defs>
+				<path id="XMLID_679_" d="M475,358l0.5-0.7L475,358z"/>
+			</defs>
+			<use xlink:href="#XMLID_679_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_198_">
+				<use xlink:href="#XMLID_679_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_680_" clip-path="url(#XMLID_198_)" fill="#F5F4F8" d="M475,358l0.5-0.7L475,358z"/>
+		</g>
+		<g id="XMLID_675_">
+			<defs>
+				<path id="XMLID_676_" d="M475.4,357.3l-25.1-0.3L475.4,357.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_676_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_199_">
+				<use xlink:href="#XMLID_676_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_677_" clip-path="url(#XMLID_199_)" fill="#F5F4F8" d="M475.4,357.3l-25.1-0.3L475.4,357.3z"/>
+		</g>
+		<g id="XMLID_672_">
+			<defs>
+				<path id="XMLID_673_" d="M450.4,357l-8.8-0.7L450.4,357z"/>
+			</defs>
+			<use xlink:href="#XMLID_673_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_201_">
+				<use xlink:href="#XMLID_673_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_674_" clip-path="url(#XMLID_201_)" fill="#F5F4F8" d="M450.4,357l-8.8-0.7L450.4,357z"/>
+		</g>
+		<g id="XMLID_669_">
+			<defs>
+				<path id="XMLID_670_" d="M441.6,356.3l3.5-5.1L441.6,356.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_670_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_202_">
+				<use xlink:href="#XMLID_670_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_671_" clip-path="url(#XMLID_202_)" fill="#F5F4F8" d="M441.6,356.3l3.5-5.1L441.6,356.3z"/>
+		</g>
+		<g id="XMLID_666_">
+			<defs>
+				<path id="XMLID_667_" d="M445.1,351.2l-67.3-0.8L445.1,351.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_667_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_203_">
+				<use xlink:href="#XMLID_667_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_668_" clip-path="url(#XMLID_203_)" fill="#F5F4F8" d="M445.1,351.2l-67.3-0.8L445.1,351.2z"/>
+		</g>
+		<g id="XMLID_663_">
+			<defs>
+				<path id="XMLID_664_" d="M377.8,350.5l-3.6,4.6L377.8,350.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_664_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_204_">
+				<use xlink:href="#XMLID_664_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_665_" clip-path="url(#XMLID_204_)" fill="#F5F4F8" d="M377.8,350.5l-3.6,4.6L377.8,350.5z"/>
+		</g>
+		<g id="XMLID_660_">
+			<defs>
+				<path id="XMLID_661_" d="M374.3,355l-14.9-0.2L374.3,355z"/>
+			</defs>
+			<use xlink:href="#XMLID_661_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_205_">
+				<use xlink:href="#XMLID_661_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_662_" clip-path="url(#XMLID_205_)" fill="#F5F4F8" d="M374.3,355l-14.9-0.2L374.3,355z"/>
+		</g>
+		<g id="XMLID_657_">
+			<defs>
+				<path id="XMLID_658_" d="M359.3,354.9l-1.4,1.7L359.3,354.9z"/>
+			</defs>
+			<use xlink:href="#XMLID_658_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_207_">
+				<use xlink:href="#XMLID_658_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_659_" clip-path="url(#XMLID_207_)" fill="#F5F4F8" d="M359.3,354.9l-1.4,1.7L359.3,354.9z"/>
+		</g>
+		<g id="XMLID_654_">
+			<defs>
+				<path id="XMLID_655_" d="M358,356.6l-26.5-0.3L358,356.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_655_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_208_">
+				<use xlink:href="#XMLID_655_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_656_" clip-path="url(#XMLID_208_)" fill="#F5F4F8" d="M358,356.6l-26.5-0.3L358,356.6z"/>
+		</g>
+		<g id="XMLID_651_">
+			<defs>
+				<path id="XMLID_652_" d="M331.5,356.3l1.8-2.2L331.5,356.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_652_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_209_">
+				<use xlink:href="#XMLID_652_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_653_" clip-path="url(#XMLID_209_)" fill="#F5F4F8" d="M331.5,356.3l1.8-2.2L331.5,356.3z"/>
+		</g>
+		<g id="XMLID_648_">
+			<defs>
+				<path id="XMLID_649_" d="M333.2,354.1l-8.1-0.1L333.2,354.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_649_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_210_">
+				<use xlink:href="#XMLID_649_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_650_" clip-path="url(#XMLID_210_)" fill="#F5F4F8" d="M333.2,354.1l-8.1-0.1L333.2,354.1z"/>
+		</g>
+		<g id="XMLID_645_">
+			<defs>
+				<path id="XMLID_646_" d="M325.1,354l1.5-1.8L325.1,354z"/>
+			</defs>
+			<use xlink:href="#XMLID_646_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_212_">
+				<use xlink:href="#XMLID_646_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_647_" clip-path="url(#XMLID_212_)" fill="#F5F4F8" d="M325.1,354l1.5-1.8L325.1,354z"/>
+		</g>
+		<g id="XMLID_642_">
+			<defs>
+				<path id="XMLID_643_" d="M326.6,352.2l-8.6-0.1L326.6,352.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_643_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_213_">
+				<use xlink:href="#XMLID_643_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_644_" clip-path="url(#XMLID_213_)" fill="#F5F4F8" d="M326.6,352.2l-8.6-0.1L326.6,352.2z"/>
+		</g>
+		<g id="XMLID_639_">
+			<defs>
+				<path id="XMLID_640_" d="M318,352.1l1.4-1.6L318,352.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_640_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_214_">
+				<use xlink:href="#XMLID_640_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_641_" clip-path="url(#XMLID_214_)" fill="#F5F4F8" d="M318,352.1l1.4-1.6L318,352.1z"/>
+		</g>
+		<g id="XMLID_636_">
+			<defs>
+				<path id="XMLID_637_" d="M319.3,350.5l-51.5-3.5L319.3,350.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_637_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_215_">
+				<use xlink:href="#XMLID_637_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_638_" clip-path="url(#XMLID_215_)" fill="#F5F4F8" d="M319.3,350.5l-51.5-3.5L319.3,350.5z"/>
+		</g>
+		<g id="XMLID_633_">
+			<defs>
+				<path id="XMLID_634_" d="M267.8,347.1l2.4-2.3L267.8,347.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_634_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_217_">
+				<use xlink:href="#XMLID_634_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_635_" clip-path="url(#XMLID_217_)" fill="#F5F4F8" d="M267.8,347.1l2.4-2.3L267.8,347.1z"/>
+		</g>
+		<g id="XMLID_630_">
+			<defs>
+				<path id="XMLID_631_" d="M270.2,344.8l-56.5-0.6L270.2,344.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_631_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_218_">
+				<use xlink:href="#XMLID_631_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_632_" clip-path="url(#XMLID_218_)" fill="#F5F4F8" d="M270.2,344.8l-56.5-0.6L270.2,344.8z"/>
+		</g>
+		<g id="XMLID_627_">
+			<defs>
+				<path id="XMLID_628_" d="M213.7,344.2l-2.1,2.1L213.7,344.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_628_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_219_">
+				<use xlink:href="#XMLID_628_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_629_" clip-path="url(#XMLID_219_)" fill="#F5F4F8" d="M213.7,344.2l-2.1,2.1L213.7,344.2z"/>
+		</g>
+		<g id="XMLID_624_">
+			<defs>
+				<path id="XMLID_625_" d="M211.6,346.3l-24.2-0.3L211.6,346.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_625_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_220_">
+				<use xlink:href="#XMLID_625_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_626_" clip-path="url(#XMLID_220_)" fill="#F5F4F8" d="M211.6,346.3l-24.2-0.3L211.6,346.3z"/>
+		</g>
+		<g id="XMLID_621_">
+			<defs>
+				<path id="XMLID_622_" d="M187.4,346.1l0.6-0.6L187.4,346.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_622_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_221_">
+				<use xlink:href="#XMLID_622_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_623_" clip-path="url(#XMLID_221_)" fill="#F5F4F8" d="M187.4,346.1l0.6-0.6L187.4,346.1z"/>
+		</g>
+		<g id="XMLID_618_">
+			<defs>
+				<path id="XMLID_619_" d="M187.9,345.5l-8.5-0.1L187.9,345.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_619_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_223_">
+				<use xlink:href="#XMLID_619_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_620_" clip-path="url(#XMLID_223_)" fill="#F5F4F8" d="M187.9,345.5l-8.5-0.1L187.9,345.5z"/>
+		</g>
+		<g id="XMLID_615_">
+			<defs>
+				<path id="XMLID_616_" d="M179.5,345.4l-2,2L179.5,345.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_616_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_224_">
+				<use xlink:href="#XMLID_616_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_617_" clip-path="url(#XMLID_224_)" fill="#F5F4F8" d="M179.5,345.4l-2,2L179.5,345.4z"/>
+		</g>
+		<g id="XMLID_612_">
+			<defs>
+				<path id="XMLID_613_" d="M177.4,347.4l-9.4-0.1L177.4,347.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_613_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_225_">
+				<use xlink:href="#XMLID_613_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_614_" clip-path="url(#XMLID_225_)" fill="#F5F4F8" d="M177.4,347.4l-9.4-0.1L177.4,347.4z"/>
+		</g>
+		<g id="XMLID_609_">
+			<defs>
+				<path id="XMLID_610_" d="M168.1,347.3l-7.1,6.8L168.1,347.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_610_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_226_">
+				<use xlink:href="#XMLID_610_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_611_" clip-path="url(#XMLID_226_)" fill="#F5F4F8" d="M168.1,347.3l-7.1,6.8L168.1,347.3z"/>
+		</g>
+		<g id="XMLID_606_">
+			<defs>
+				<path id="XMLID_607_" d="M161,354.1l-23.7-0.3L161,354.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_607_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_228_">
+				<use xlink:href="#XMLID_607_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_608_" clip-path="url(#XMLID_228_)" fill="#F5F4F8" d="M161,354.1l-23.7-0.3L161,354.1z"/>
+		</g>
+		<g id="XMLID_603_">
+			<defs>
+				<path id="XMLID_604_" d="M137.3,353.8l7.3-6.8L137.3,353.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_604_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_229_">
+				<use xlink:href="#XMLID_604_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_605_" clip-path="url(#XMLID_229_)" fill="#F5F4F8" d="M137.3,353.8l7.3-6.8L137.3,353.8z"/>
+		</g>
+		<g id="XMLID_600_">
+			<defs>
+				<path id="XMLID_601_" d="M144.6,347l-12.4-0.1L144.6,347z"/>
+			</defs>
+			<use xlink:href="#XMLID_601_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_230_">
+				<use xlink:href="#XMLID_601_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_602_" clip-path="url(#XMLID_230_)" fill="#F5F4F8" d="M144.6,347l-12.4-0.1L144.6,347z"/>
+		</g>
+		<g id="XMLID_597_">
+			<defs>
+				<path id="XMLID_598_" d="M132.2,346.9l-5.7,5.2L132.2,346.9z"/>
+			</defs>
+			<use xlink:href="#XMLID_598_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_231_">
+				<use xlink:href="#XMLID_598_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_599_" clip-path="url(#XMLID_231_)" fill="#F5F4F8" d="M132.2,346.9l-5.7,5.2L132.2,346.9z"/>
+		</g>
+		<g id="XMLID_594_">
+			<defs>
+				<path id="XMLID_595_" d="M126.5,352.1l-25.4-0.3L126.5,352.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_595_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_233_">
+				<use xlink:href="#XMLID_595_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_596_" clip-path="url(#XMLID_233_)" fill="#F5F4F8" d="M126.5,352.1l-25.4-0.3L126.5,352.1z"/>
+		</g>
+		<g id="XMLID_591_">
+			<defs>
+				<path id="XMLID_592_" d="M101.1,351.8l5.8-5.2L101.1,351.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_592_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_234_">
+				<use xlink:href="#XMLID_592_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_593_" clip-path="url(#XMLID_234_)" fill="#F5F4F8" d="M101.1,351.8l5.8-5.2L101.1,351.8z"/>
+		</g>
+		<g id="XMLID_588_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_589_" enable-background="new    " d="M106.9,346.6l-37.8-0.4L106.9,346.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_589_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_235_">
+				<use xlink:href="#XMLID_589_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_590_" clip-path="url(#XMLID_235_)" fill="#F5F4F8" d="M106.9,346.6l-37.8-0.4L106.9,346.6z"/>
+		</g>
+		<g id="XMLID_585_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_586_" enable-background="new    " d="M69.1,346.1l-19.5-0.3L69.1,346.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_586_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_236_">
+				<use xlink:href="#XMLID_586_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_587_" clip-path="url(#XMLID_236_)" fill="#F5F4F8" d="M69.1,346.1l-19.5-0.3L69.1,346.1z"/>
+		</g>
+		<g id="XMLID_582_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_583_" enable-background="new    " d="M49.6,345.8l-4.6,3.8L49.6,345.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_583_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_237_">
+				<use xlink:href="#XMLID_583_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_584_" clip-path="url(#XMLID_237_)" fill="#F5F4F8" d="M49.6,345.8l-4.6,3.8L49.6,345.8z"/>
+		</g>
+		<g id="XMLID_579_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_580_" enable-background="new    " d="M45,349.6l-16.2-0.2L45,349.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_580_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_239_">
+				<use xlink:href="#XMLID_580_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_581_" clip-path="url(#XMLID_239_)" fill="#F5F4F8" d="M45,349.6l-16.2-0.2L45,349.6z"/>
+		</g>
+		<g id="XMLID_576_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_577_" enable-background="new    " d="M28.8,349.5l4.7-3.8L28.8,349.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_577_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_240_">
+				<use xlink:href="#XMLID_577_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_578_" clip-path="url(#XMLID_240_)" fill="#F5F4F8" d="M28.8,349.5l4.7-3.8L28.8,349.5z"/>
+		</g>
+		<g id="XMLID_573_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_574_" enable-background="new    " d="M33.4,345.6l2.7-2.2L33.4,345.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_574_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_241_">
+				<use xlink:href="#XMLID_574_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_575_" clip-path="url(#XMLID_241_)" fill="#F5F4F8" d="M33.4,345.6l2.7-2.2L33.4,345.6z"/>
+		</g>
+		<g id="XMLID_570_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_571_" enable-background="new    " d="M36.2,343.4l-8.8-0.1L36.2,343.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_571_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_242_">
+				<use xlink:href="#XMLID_571_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_572_" clip-path="url(#XMLID_242_)" fill="#F5F4F8" d="M36.2,343.4l-8.8-0.1L36.2,343.4z"/>
+		</g>
+		<g id="XMLID_567_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_568_" enable-background="new    " d="M27.3,343.3l-1.4,1.1L27.3,343.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_568_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_244_">
+				<use xlink:href="#XMLID_568_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_569_" clip-path="url(#XMLID_244_)" fill="#F5F4F8" d="M27.3,343.3l-1.4,1.1L27.3,343.3z"/>
+		</g>
+		<g id="XMLID_564_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_565_" enable-background="new    " d="M25.9,344.4l-8.2-0.1L25.9,344.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_565_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_245_">
+				<use xlink:href="#XMLID_565_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_566_" clip-path="url(#XMLID_245_)" fill="#F5F4F8" d="M25.9,344.4l-8.2-0.1L25.9,344.4z"/>
+		</g>
+		<g id="XMLID_561_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_562_" enable-background="new    " d="M17.7,344.3l-1.7,1.4L17.7,344.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_562_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_246_">
+				<use xlink:href="#XMLID_562_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_563_" clip-path="url(#XMLID_246_)" fill="#F5F4F8" d="M17.7,344.3l-1.7,1.4L17.7,344.3z"/>
+		</g>
+		<g id="XMLID_558_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_559_" enable-background="new    " d="M16,345.7l-9.7-0.1L16,345.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_559_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_247_">
+				<use xlink:href="#XMLID_559_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_560_" clip-path="url(#XMLID_247_)" fill="#F5F4F8" d="M16,345.7l-9.7-0.1L16,345.7z"/>
+		</g>
+		<g id="XMLID_555_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_556_" enable-background="new    " d="M6.3,345.6l1.7-1.4L6.3,345.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_556_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_249_">
+				<use xlink:href="#XMLID_556_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_557_" clip-path="url(#XMLID_249_)" fill="#F5F4F8" d="M6.3,345.6l1.7-1.4L6.3,345.6z"/>
+		</g>
+		<g id="XMLID_552_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_553_" enable-background="new    " d="M8,344.2l-8-0.1L8,344.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_553_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_250_">
+				<use xlink:href="#XMLID_553_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_554_" clip-path="url(#XMLID_250_)" fill="#F5F4F8" d="M8,344.2l-8-0.1L8,344.2z"/>
+		</g>
+		<g id="XMLID_549_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_550_" enable-background="new    " d="M0,344.1l34.9-27.8L0,344.1z"/>
+			</defs>
+			<use xlink:href="#XMLID_550_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_251_">
+				<use xlink:href="#XMLID_550_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_551_" clip-path="url(#XMLID_251_)" fill="#F5F4F8" d="M0,344.1l34.9-27.8L0,344.1z"/>
+		</g>
+		<g id="XMLID_546_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_547_" enable-background="new    " d="M34.9,316.4l10.7,0.1L34.9,316.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_547_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_252_">
+				<use xlink:href="#XMLID_547_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_548_" clip-path="url(#XMLID_252_)" fill="#F5F4F8" d="M34.9,316.4l10.7,0.1L34.9,316.4z"/>
+		</g>
+		<g id="XMLID_543_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_544_" enable-background="new    " d="M45.6,316.4l8.2-6.6L45.6,316.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_544_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_253_">
+				<use xlink:href="#XMLID_544_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_545_" clip-path="url(#XMLID_253_)" fill="#F5F4F8" d="M45.6,316.4l8.2-6.6L45.6,316.4z"/>
+		</g>
+		<g id="XMLID_540_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_541_" enable-background="new    " d="M53.8,309.8l-14-0.1L53.8,309.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_541_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_255_">
+				<use xlink:href="#XMLID_541_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_542_" clip-path="url(#XMLID_255_)" fill="#F5F4F8" d="M53.8,309.8l-14-0.1L53.8,309.8z"/>
+		</g>
+		<g id="XMLID_537_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_538_" enable-background="new    " d="M39.9,309.8l7.7-6.1L39.9,309.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_538_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_256_">
+				<use xlink:href="#XMLID_538_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_539_" clip-path="url(#XMLID_256_)" fill="#F5F4F8" d="M39.9,309.8l7.7-6.1L39.9,309.8z"/>
+		</g>
+		<g id="XMLID_534_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_535_" enable-background="new    " d="M47.6,303.7l8.5,0L47.6,303.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_535_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_257_">
+				<use xlink:href="#XMLID_535_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_536_" clip-path="url(#XMLID_257_)" fill="#F5F4F8" d="M47.6,303.7l8.5,0L47.6,303.7z"/>
+		</g>
+		<g id="XMLID_531_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_532_" enable-background="new    " d="M56.1,303.7l6.8-5.4L56.1,303.7z"/>
+			</defs>
+			<use xlink:href="#XMLID_532_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_258_">
+				<use xlink:href="#XMLID_532_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_533_" clip-path="url(#XMLID_258_)" fill="#F5F4F8" d="M56.1,303.7l6.8-5.4L56.1,303.7z"/>
+		</g>
+		<g id="XMLID_528_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_529_" enable-background="new    " d="M62.8,298.3l-6.7,0L62.8,298.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_529_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_260_">
+				<use xlink:href="#XMLID_529_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_530_" clip-path="url(#XMLID_260_)" fill="#F5F4F8" d="M62.8,298.3l-6.7,0L62.8,298.3z"/>
+		</g>
+		<g id="XMLID_525_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_526_" enable-background="new    " d="M56.1,298.3l2-1.6L56.1,298.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_526_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_261_">
+				<use xlink:href="#XMLID_526_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_527_" clip-path="url(#XMLID_261_)" fill="#F5F4F8" d="M56.1,298.3l2-1.6L56.1,298.3z"/>
+		</g>
+		<g id="XMLID_522_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_523_" enable-background="new    " d="M58.2,296.6l13.3-11.2L58.2,296.6z"/>
+			</defs>
+			<use xlink:href="#XMLID_523_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_262_">
+				<use xlink:href="#XMLID_523_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_524_" clip-path="url(#XMLID_262_)" fill="#F5F4F8" d="M58.2,296.6l13.3-11.2L58.2,296.6z"/>
+		</g>
+		<g id="XMLID_519_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_520_" enable-background="new    " d="M71.5,285.5l2.6-1.5L71.5,285.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_520_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_263_">
+				<use xlink:href="#XMLID_520_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_521_" clip-path="url(#XMLID_263_)" fill="#F5F4F8" d="M71.5,285.5l2.6-1.5L71.5,285.5z"/>
+		</g>
+		<g id="XMLID_516_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_517_" enable-background="new    " d="M74.1,284l6.6,0L74.1,284z"/>
+			</defs>
+			<use xlink:href="#XMLID_517_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_265_">
+				<use xlink:href="#XMLID_517_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_518_" clip-path="url(#XMLID_265_)" fill="#F5F4F8" d="M74.1,284l6.6,0L74.1,284z"/>
+		</g>
+		<g id="XMLID_513_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_514_" enable-background="new    " d="M80.7,284l6.5-5.2L80.7,284z"/>
+			</defs>
+			<use xlink:href="#XMLID_514_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_266_">
+				<use xlink:href="#XMLID_514_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_515_" clip-path="url(#XMLID_266_)" fill="#F5F4F8" d="M80.7,284l6.5-5.2L80.7,284z"/>
+		</g>
+		<g id="XMLID_510_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_511_" enable-background="new    " d="M87.2,278.8l-8.1,0L87.2,278.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_511_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_267_">
+				<use xlink:href="#XMLID_511_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_512_" clip-path="url(#XMLID_267_)" fill="#F5F4F8" d="M87.2,278.8l-8.1,0L87.2,278.8z"/>
+		</g>
+		<g id="XMLID_507_" enable-background="new    ">
+			<defs>
+				<path id="XMLID_508_" enable-background="new    " d="M79.2,278.8l6.9-5.5L79.2,278.8z"/>
+			</defs>
+			<use xlink:href="#XMLID_508_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_268_">
+				<use xlink:href="#XMLID_508_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_509_" clip-path="url(#XMLID_268_)" fill="#F5F4F8" d="M79.2,278.8l6.9-5.5L79.2,278.8z"/>
+		</g>
+		<g id="XMLID_504_">
+			<defs>
+				<path id="XMLID_505_" d="M86.1,273.3l8,0L86.1,273.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_505_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_269_">
+				<use xlink:href="#XMLID_505_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_506_" clip-path="url(#XMLID_269_)" fill="#F5F4F8" d="M86.1,273.3l8,0L86.1,273.3z"/>
+		</g>
+		<g id="XMLID_501_">
+			<defs>
+				<path id="XMLID_502_" d="M94.1,273.3l25-20L94.1,273.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_502_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_271_">
+				<use xlink:href="#XMLID_502_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_503_" clip-path="url(#XMLID_271_)" fill="#F5F4F8" d="M94.1,273.3l25-20L94.1,273.3z"/>
+		</g>
+		<g id="XMLID_498_">
+			<defs>
+				<path id="XMLID_499_" d="M119.1,253.3l14.8-0.1L119.1,253.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_499_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_272_">
+				<use xlink:href="#XMLID_499_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_500_" clip-path="url(#XMLID_272_)" fill="#F5F4F8" d="M119.1,253.3l14.8-0.1L119.1,253.3z"/>
+		</g>
+		<g id="XMLID_495_">
+			<defs>
+				<path id="XMLID_496_" d="M133.9,253.2l-10.5,0.1L133.9,253.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_496_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_273_">
+				<use xlink:href="#XMLID_496_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_497_" clip-path="url(#XMLID_273_)" fill="#F5F4F8" d="M133.9,253.2l-10.5,0.1L133.9,253.2z"/>
+		</g>
+		<g id="XMLID_492_">
+			<defs>
+				<path id="XMLID_493_" d="M123.4,253.2l11.6-9.4L123.4,253.2z"/>
+			</defs>
+			<use xlink:href="#XMLID_493_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_274_">
+				<use xlink:href="#XMLID_493_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_494_" clip-path="url(#XMLID_274_)" fill="#F5F4F8" d="M123.4,253.2l11.6-9.4L123.4,253.2z"/>
+		</g>
+		<g id="XMLID_489_">
+			<defs>
+				<path id="XMLID_490_" d="M135.1,243.9l3.1,0L135.1,243.9z"/>
+			</defs>
+			<use xlink:href="#XMLID_490_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_276_">
+				<use xlink:href="#XMLID_490_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_491_" clip-path="url(#XMLID_276_)" fill="#F5F4F8" d="M135.1,243.9l3.1,0L135.1,243.9z"/>
+		</g>
+		<g id="XMLID_486_">
+			<defs>
+				<path id="XMLID_487_" d="M138.2,243.9l5.6-4.5L138.2,243.9z"/>
+			</defs>
+			<use xlink:href="#XMLID_487_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_277_">
+				<use xlink:href="#XMLID_487_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_488_" clip-path="url(#XMLID_277_)" fill="#F5F4F8" d="M138.2,243.9l5.6-4.5L138.2,243.9z"/>
+		</g>
+		<g id="XMLID_483_">
+			<defs>
+				<path id="XMLID_484_" d="M143.8,239.4l4.8,0L143.8,239.4z"/>
+			</defs>
+			<use xlink:href="#XMLID_484_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_278_">
+				<use xlink:href="#XMLID_484_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_485_" clip-path="url(#XMLID_278_)" fill="#F5F4F8" d="M143.8,239.4l4.8,0L143.8,239.4z"/>
+		</g>
+		<g id="XMLID_480_">
+			<defs>
+				<path id="XMLID_481_" d="M148.5,239.3l3.5-2.8L148.5,239.3z"/>
+			</defs>
+			<use xlink:href="#XMLID_481_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_279_">
+				<use xlink:href="#XMLID_481_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_482_" clip-path="url(#XMLID_279_)" fill="#F5F4F8" d="M148.5,239.3l3.5-2.8L148.5,239.3z"/>
+		</g>
+		<g id="XMLID_477_">
+			<defs>
+				<path id="XMLID_478_" d="M152.1,236.5l73.6-0.8L152.1,236.5z"/>
+			</defs>
+			<use xlink:href="#XMLID_478_"  overflow="visible" fill="#F5F4F8"/>
+			<clipPath id="XMLID_281_">
+				<use xlink:href="#XMLID_478_"  overflow="visible"/>
+			</clipPath>
+			<path id="XMLID_479_" clip-path="url(#XMLID_281_)" fill="#F5F4F8" d="M152.1,236.5l73.6-0.8L152.1,236.5z"/>
+		</g>
+	</g>
+</g>
+<g>
+	<g id="XMLID_471_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#CDCCCF" points="142.3,238.5 142.8,242.4 128.7,242.5 128.2,238.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="147.4,234.1 147.9,237.9 142.8,242.4 142.3,238.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="233.4,233.7 233.9,237.6 147.9,237.9 147.4,234.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E5E8" points="128.2,238.6 128.7,242.5 117.6,252.5 117,248.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="117,248.6 117.6,252.5 113.4,252.6 112.8,248.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E5E8" points="112.8,248.7 113.4,252.6 77.7,284.6 77.1,280.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="77.1,280.7 77.7,284.6 70.1,284.7 69.5,280.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#F0F0F0" points="233.4,233.7 233.9,237.6 199.4,271.8 198.9,267.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="234.6,233.3 235.1,237.2 200.3,271.8 199.8,267.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="69.5,280.7 70.1,284.7 54.5,298.7 53.9,294.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="61.2,294.7 61.8,298.7 54.5,298.7 53.9,294.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="59.9,295 60.5,299 53.2,299 52.6,295 					"/>
+				</g>
+				<g>
+					<polygon fill="#EAEAEA" points="198.9,267.8 199.4,271.8 194.3,287.6 193.8,283.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E1E0E4" points="199.8,267.8 200.3,271.8 195.3,287.5 194.8,283.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#BBBABD" points="199.9,285.9 200.4,289.9 194.3,287.7 193.8,283.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E5E8" points="61.2,294.7 61.8,298.7 48.8,310.4 48.2,306.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="53.4,306.3 54,310.4 48.8,310.4 48.2,306.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="52.1,306.7 52.7,310.7 47.5,310.7 46.9,306.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#C9C8CB" points="225.3,287.9 225.8,292 200.4,289.9 199.9,285.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#BEBDC0" points="476,258 476.5,262.1 465.3,258.5 464.9,254.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E5E8" points="53.4,306.3 54,310.4 46.3,317.3 45.7,313.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="45.7,313.3 46.3,317.3 36,317.3 35.4,313.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="495.9,258 496.4,262 476.5,262.1 476,258 					"/>
+				</g>
+				<g>
+					<polygon fill="#CFCED1" points="508.7,257.2 509.2,261.3 496.4,262 495.9,258 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCD0" points="271.9,287.1 272.4,291.2 225.8,292 225.3,287.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#B7B6B9" points="514.2,259.8 514.7,263.9 509.2,261.3 508.7,257.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C9C8CB" points="539.8,262.2 540.2,266.3 514.7,263.9 514.2,259.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#C6C6C9" points="308.9,292.3 309.4,296.4 272.4,291.2 271.9,287.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D3D7" points="464.9,254.4 465.3,258.5 460.8,278.3 460.4,274.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#B7B7BA" points="553.3,268.4 553.7,272.5 540.2,266.3 539.8,262.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#DDDCDF" points="460.4,274.2 460.8,278.3 435.9,289.9 435.4,285.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCBCE" points="373.1,294 373.5,298.1 309.4,296.4 308.9,292.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="35.4,313.2 36,317.3 6.2,344 5.6,339.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#D0CFD3" points="390.3,292.5 390.8,296.6 373.5,298.1 373.1,294 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="13.5,339.9 14.1,344 6.2,344 5.6,339.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="12.1,340.2 12.8,344.4 4.9,344.3 4.3,340.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E5E8" points="13.5,339.9 14.1,344 12.8,345.2 12.1,341.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D9D8DC" points="435.4,285.7 435.9,289.9 419.7,295.4 419.3,291.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD1" points="419.3,291.3 419.7,295.4 390.8,296.6 390.3,292.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="553.3,268.4 553.7,272.5 548.2,279.8 547.8,275.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="554.4,268.2 554.8,272.4 549.4,279.5 549,275.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="30.9,339.9 31.6,344 23.2,344 22.6,339.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="31.9,339 32.5,343.1 31.6,344 30.9,339.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="22.6,339.8 23.2,344 21.8,345.3 21.2,341.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="21.2,341.1 21.8,345.3 12.8,345.2 12.1,341.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="41.8,339.1 42.4,343.2 32.5,343.1 31.9,339 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="32.4,339.4 33,343.5 32.1,344.4 31.5,340.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="31.5,340.2 32.1,344.4 23.8,344.3 23.1,340.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="23.1,340.2 23.8,344.3 22.3,345.6 21.7,341.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="21.7,341.5 22.3,345.6 11.5,345.6 10.8,341.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="40.5,339.4 41.1,343.6 33,343.5 32.4,339.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="554.9,275.6 555.3,279.8 548.2,279.8 547.8,275.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="41.8,339.1 42.4,343.2 40.3,345.1 39.7,341 					"/>
+				</g>
+				<g>
+					<polygon fill="#C5C4C7" points="562.2,277 562.6,281.1 555.3,279.8 554.9,275.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#A7A6A9" points="565.3,279.4 565.7,283.6 562.6,281.1 562.2,277 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="565.3,279.4 565.7,283.6 563.5,286.5 563.1,282.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="566.3,279.3 566.8,283.5 564.4,286.6 564,282.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#E4E4E4" points="563.1,282.3 563.5,286.5 556.8,289.2 556.3,285 					"/>
+				</g>
+				<g>
+					<polygon fill="#DBDBDB" points="556.3,285 556.8,289.2 547.5,290.6 547,286.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#DBDADD" points="564,282.4 564.4,286.6 557.3,289.4 556.8,285.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D3D2D5" points="556.8,285.2 557.3,289.4 548.3,290.9 547.9,286.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="543.3,291.3 543.7,295.6 539.3,295.6 538.9,291.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="547,286.4 547.5,290.6 543.7,295.6 543.3,291.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="544,291.7 544.4,295.9 540,295.9 539.6,291.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="547.9,286.7 548.3,290.9 544.4,295.9 544,291.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="192.6,339.9 193.2,344.1 184.4,344.1 183.9,339.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="191.3,340.3 191.9,344.5 185,344.4 184.5,340.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="182,341.7 182.6,345.9 40.3,345.1 39.7,341 					"/>
+				</g>
+				<g>
+					<polygon fill="#F0F0F0" points="183.9,339.8 184.4,344.1 182.6,345.9 182,341.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E6E9" points="192.6,339.9 193.2,344.1 192.5,344.8 191.9,340.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="184.5,340.2 185,344.4 183.2,346.3 182.6,342.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="182.6,342.1 183.2,346.3 39,345.5 38.4,341.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#F0F0F0" points="217.1,338.8 217.7,343 215.8,344.9 215.2,340.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="215.2,340.7 215.8,344.9 192.5,344.8 192,340.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="272.7,339 273.2,343.3 217.7,343 217.1,338.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6E9" points="217.7,339.1 218.3,343.3 216.4,345.3 215.8,341.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="215.8,341.1 216.4,345.3 191.2,345.2 190.6,341 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="538.9,291.3 539.3,295.6 529.1,308.2 528.7,304 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="528.7,304 529.1,308.2 521.5,308.2 521.1,304 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="539.6,291.7 540,295.9 529.8,308.6 529.4,304.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="529.4,304.3 529.8,308.6 522.3,308.6 521.8,304.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="271.3,339.4 271.9,343.6 218.3,343.3 217.7,339.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="272.7,339 273.2,343.3 271.2,345.4 270.7,341.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D2D2D2" points="320.2,344.1 320.7,348.4 271.2,345.4 270.7,341.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CAC9CC" points="318.9,344.5 319.4,348.7 270,345.7 269.4,341.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="320.2,344.1 320.7,348.4 319.5,349.8 318.9,345.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="327.2,345.5 327.7,349.8 319.5,349.8 318.9,345.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="325.8,345.9 326.4,350.2 318.1,350.1 317.6,345.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="333.3,347.2 333.9,351.5 326.2,351.5 325.7,347.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="332,347.6 332.5,351.9 324.9,351.8 324.4,347.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="333.3,347.2 333.9,351.5 332.2,353.4 331.7,349.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="521.1,304 521.5,308.2 501.1,334.8 500.7,330.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="521.8,304.3 522.3,308.6 502.4,334.4 502,330.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="522.9,330.5 523.4,334.9 501.1,334.8 500.7,330.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="448.2,343.5 448.6,347.8 361.8,347.3 361.3,343 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="446.8,343.9 447.3,348.2 362.5,347.7 362,343.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="448.2,343.5 448.6,347.8 444.2,353.4 443.7,349.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="466,349.2 466.5,353.6 444.2,353.4 443.7,349.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="466,349.2 466.5,353.6 465.9,354.2 465.5,349.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="356,349.2 356.5,353.5 332.2,353.4 331.7,349.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="361.3,343 361.8,347.3 356.5,353.5 356,349.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="522.9,330.5 523.4,334.9 517.1,343.3 516.6,338.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="464.7,349.6 465.1,353.9 442.9,353.8 442.4,349.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="516.6,338.9 517.1,343.3 509.9,354.5 509.5,350.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="509.5,350.2 509.9,354.5 465.9,354.2 465.5,349.9 					"/>
+				</g>
+				<g>
+					<path fill="#DEDDE1" d="M529.4,304.3l-7.6,0L502,330.1l22.3,0.1l-6.3,8.4l-7.6,12l-46.1-0.3l0.5-0.7l-22.3-0.1l4.5-5.6
+						l-84.8-0.5l-5.4,6.2l-26.3-0.2l1.6-1.9l-7.6,0l1.4-1.6l-8.2,0l1.3-1.4l-49.5-3l1.9-2.1l-53.6-0.3l-1.9,2l-25.2-0.1l0.7-0.7
+						l-6.9,0l-1.9,1.9l-144.2-0.8l2.1-1.9l-8.1,0l-1,0.9l-8.3,0l-1.4,1.3l-10.9-0.1l1.3-1.2l-7.8,0l30.6-27.3l10.3,0l6.9-6.2l-5.2,0
+						l13-11.6l-7.3,0L69,280.3l7.6,0l35.7-32l4.2,0l11.2-10l14.1-0.1l5.1-4.5l87.7-0.4l-34.8,34.5l-5,15.6l5.8,2.1l25.1,2l46.7-0.8
+						l37.1,5.2l63.8,1.7l17.2-1.5l28.5-1.2l15.7-5.4l24.7-11.4l4.7-20.5l12.5,4.1l19.5-0.1l13.2-0.7l5.6,2.6l25.5,2.4l13.9,6.4
+						l-5.4,7.1l6.4,0l7.7,1.4l3.3,2.6l-2.3,3.1l-7.2,2.9l-9,1.4l-3.8,5l-4.4,0L529.4,304.3z M522.9,330.5l-22.3-0.1l20.4-26.5l7.6,0
+						l10.2-12.6l4.4,0l3.7-4.9l9.3-1.5l6.8-2.7l2.2-2.9l-3.1-2.4l-7.4-1.3l-7.1,0l5.6-7.3l-13.6-6.2l-25.5-2.4l-5.5-2.6l-12.8,0.7
+						L476,258l-11.2-3.6l-4.5,19.8l-25,11.5l-16.1,5.5l-28.9,1.2l-17.3,1.5l-64.2-1.7l-37-5.1l-46.6,0.8l-25.4-2l-6.1-2.2l5.1-15.8
+						l34.5-34.2l-86,0.4l-5.1,4.5l-14.1,0.1l-11.2,10l-4.2,0l-35.7,32l-7.6,0l-15.7,14l7.3,0l-13,11.6l5.2,0l-7.7,6.9l-10.3,0
+						L5.6,339.8l7.8,0l-1.3,1.2l9,0l1.4-1.3l8.3,0l1-0.9l9.9,0.1l-2.1,1.9l142.3,0.8l1.9-1.9l8.8,0l-0.7,0.7l23.2,0.1l1.9-2
+						l55.6,0.3l-2,2.1l49.5,3l-1.2,1.4l8.2,0l-1.4,1.6l7.6,0l-1.6,1.9l24.3,0.1l5.4-6.2l86.8,0.5l-4.5,5.6l22.3,0.1l-0.5,0.7l44,0.3
+						l7.4-11.2L522.9,330.5"/>
+				</g>
+				<g>
+					<polygon fill="#E7E7E7" points="147.4,234.1 233.4,233.7 198.9,267.8 193.8,283.6 199.9,285.9 225.2,287.9 271.9,287.1 
+						308.9,292.3 373.1,294 390.3,292.5 419.3,291.3 435.4,285.7 460.3,274.2 464.9,254.4 476,258 495.9,258 508.7,257.2 
+						514.2,259.8 539.8,262.2 553.3,268.4 547.8,275.6 554.9,275.6 562.2,277 565.3,279.4 563.1,282.3 556.3,285 547,286.4 
+						543.3,291.3 538.9,291.3 528.7,304 521.1,304 500.7,330.4 522.9,330.5 516.6,338.9 509.5,350.2 465.5,349.9 466,349.2 
+						443.7,349.1 448.2,343.5 361.3,343 356,349.2 331.7,349.1 333.3,347.2 325.7,347.2 327.2,345.5 318.9,345.5 320.2,344.1 
+						270.7,341.2 272.7,339 217.1,338.8 215.2,340.7 192,340.6 192.6,339.9 183.9,339.8 182,341.7 39.7,341 41.8,339.1 31.9,339 
+						30.9,339.9 22.6,339.8 21.2,341.1 12.1,341.1 13.5,339.9 5.6,339.8 35.4,313.2 45.7,313.3 53.4,306.3 48.2,306.3 61.2,294.7 
+						53.9,294.7 69.5,280.7 77.1,280.7 112.8,248.7 117,248.6 128.2,238.6 142.3,238.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="327.2,345.5 325.7,347.2 327.4,347.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="356.6,349.6 357.2,353.9 330.9,353.7 330.4,349.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="362,343.4 362.5,347.7 357.2,353.9 356.6,349.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="524.2,330.2 524.7,334.5 518.4,342.9 517.9,338.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="517.9,338.6 518.4,342.9 510.7,354.9 510.3,350.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="510.3,350.5 510.7,354.9 464.6,354.6 464.1,350.3 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#835165" points="245,216 247.2,231.8 159.9,231.9 157.6,216.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="157.6,216.4 159.9,231.9 108.7,276.7 106.2,260.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B68" points="196.8,260.1 199.2,276.3 108.7,276.7 106.2,260.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#BE6371" points="245,216 196.8,260.1 106.2,260.7 157.6,216.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="245,216 247.2,231.8 199.2,276.3 196.8,260.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#835165" points="197.4,260.5 199.7,276.6 107.4,277.1 104.9,261.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="246.3,215.7 248.5,231.4 199.7,276.6 197.4,260.5 					"/>
+				</g>
+				<g>
+					<path fill="#8E576E" d="M157,216l89.2-0.3l-48.9,44.8l-92.5,0.6L157,216z M196.8,260.1L245,216l-87.5,0.3l-51.3,44.4
+						L196.8,260.1"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#935A72" points="121.7,260.4 124.1,275.9 104.7,292 102.2,276.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#835165" points="102.2,276.4 104.7,292 99.5,292 97,276.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#835165" points="252.1,259.8 254.4,275.5 124.1,275.9 121.7,260.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A72" points="97,276.4 99.5,292 87.2,302.2 84.7,286.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B68" points="90,286.5 92.5,302.2 87.2,302.2 84.7,286.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#835065" points="88.7,286.9 91.2,302.6 85.9,302.6 83.4,286.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A72" points="90,286.5 92.5,302.2 65.5,324.7 63,308.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#975C74" points="63,308.8 65.5,324.7 65.4,324.9 62.8,308.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A72" points="62.8,308.9 65.4,324.9 58.7,330.4 56.1,314.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B68" points="87.3,314.5 89.9,330.6 58.7,330.4 56.1,314.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#835065" points="86,314.9 88.6,330.9 57.4,330.8 54.8,314.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="87.3,314.5 89.9,330.6 87.9,332.3 85.3,316.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B68" points="127.6,316.3 130.2,332.5 87.9,332.3 85.3,316.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C56775" points="129.6,314.6 132.1,330.8 130.2,332.5 127.6,316.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B68" points="160.2,314.7 162.7,330.9 132.1,330.8 129.6,314.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="130.1,315 132.6,331.1 130.7,332.8 128.1,316.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#835065" points="128.1,316.7 130.7,332.8 86.6,332.6 84,316.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B68" points="197.1,309 199.5,325.2 169.3,325.1 166.8,308.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="252.1,259.8 254.4,275.5 199.5,325.2 197.1,309 					"/>
+				</g>
+				<g>
+					<polygon fill="#BE6371" points="252.1,259.8 197.1,309 166.8,308.9 160.2,314.7 129.6,314.6 127.6,316.3 85.3,316.2 
+						87.3,314.5 56.1,314.4 62.8,308.9 63,308.8 90,286.5 84.7,286.5 97,276.4 102.2,276.4 121.7,260.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C56775" points="166.8,308.9 169.3,325.1 162.7,330.9 160.2,314.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#835065" points="197.6,309.3 200,325.6 169.8,325.5 167.3,309.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="253.4,259.4 255.7,275.2 200,325.6 197.6,309.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#835065" points="160.7,315.1 163.2,331.3 132.6,331.1 130.1,315 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="167.3,309.3 169.8,325.5 163.2,331.3 160.7,315.1 					"/>
+				</g>
+				<g>
+					<path fill="#8E576E" d="M121.2,260.1l132.2-0.6l-55.8,49.9l-30.3-0.1l-6.6,5.8l-30.6-0.1l-2,1.7L84,316.5l2-1.7l-31.2-0.1
+						l6.9-5.7l0.1-0.2l26.8-22.1l-5.2,0l13.1-10.8l5.2,0L121.2,260.1z M197.1,309l55.1-49.2l-130.5,0.6l-19.4,16l-5.2,0l-12.3,10.1
+						l5.2,0l-27,22.2l-0.1,0.2l-6.7,5.5l31.2,0.1l-2,1.7l42.3,0.1l2-1.7l30.6,0.1l6.6-5.8L197.1,309"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_463_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="339.2,259.3 341.3,275 253.2,275.2 251.1,259.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="251.1,259.7 253.2,275.2 201.3,325 198.9,308.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="289.8,309.1 292,325.3 201.3,325 198.9,308.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="339.2,259.3 289.8,309.1 198.9,308.9 251.1,259.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66776" points="339.2,259.3 341.3,275 292,325.3 289.8,309.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#835166" points="290.4,309.5 292.6,325.7 200,325.3 197.7,309.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="340.5,259 342.5,274.7 292.6,325.7 290.4,309.5 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M340.5,259l-50.1,50.5l-92.8-0.2l52.9-49.9L340.5,259z M198.9,308.9l90.9,0.2l49.4-49.8l-88.1,0.3
+						L198.9,308.9"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_459_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="401.2,259.5 403.1,275.2 340.9,274.7 339,259.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="339,259.2 340.9,274.7 293.4,324.9 291.4,308.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="355.6,309 357.6,325.1 293.4,324.9 291.4,308.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="339,259.2 401.2,259.5 355.6,309 291.4,308.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="401.2,259.5 403.1,275.2 357.6,325.1 355.6,309 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="356.3,309.3 358.3,325.5 292.2,325.2 290.1,309.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="402.5,259.2 404.3,274.8 358.3,325.5 356.3,309.3 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M338.9,258.9l63.6,0.3l-46.2,50.1l-66.2-0.1l48.3-50.3L338.9,258.9z M355.6,309l45.6-49.5l-62.2-0.3
+						l-47.6,49.7L355.6,309"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_455_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="488.4,240.7 490.6,258.6 451.2,258.6 449,240.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="449,240.8 451.2,258.6 440.6,269.7 438.4,251.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="478.6,251.8 480.8,269.8 440.6,269.7 438.4,251.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="488.4,240.7 478.6,251.8 438.4,251.8 449,240.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="488.4,240.7 490.6,258.6 480.8,269.8 478.6,251.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="479.2,252.1 481.4,270.1 439.4,270.1 437.1,252.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="489.6,240.4 491.8,258.3 481.4,270.1 479.2,252.1 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M489.6,240.4l-10.4,11.7l-42.1,0l11.3-11.7L489.6,240.4z M438.4,251.8l40.2,0l9.8-11.1l-39.4,0.1
+						L438.4,251.8"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_451_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="509.6,240.8 511.6,258.6 491.1,258.6 489.1,240.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#744759" points="517.8,245.2 519.8,263.1 511.6,258.6 509.6,240.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="518.9,245.1 520.9,263 520.8,263.1 518.8,245.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="489.1,240.8 491.1,258.6 481.6,269.7 479.5,251.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="517.8,245.2 519.8,263.1 513.9,269.5 511.9,251.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="511.9,251.5 513.9,269.5 481.6,269.7 479.5,251.8 					"/>
+				</g>
+				<g>
+					<path fill="#8F586F" d="M510.3,240.4l8.6,4.6l-0.1,0.1l-6.3,6.7l-34.3,0.3l10.2-11.7L510.3,240.4z M511.9,251.5l5.9-6.3
+						l-8.3-4.4l-20.5,0l-9.6,11L511.9,251.5"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="489.1,240.8 509.6,240.8 517.8,245.2 511.9,251.5 479.5,251.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="512.6,251.9 514.6,269.9 480.3,270.1 478.3,252.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="518.8,245.1 520.8,263.1 514.6,269.9 512.6,251.9 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="511.8,252 513.9,269.8 439.9,269.8 437.8,252.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="437.8,252.1 439.9,269.8 422.7,288.7 420.5,270.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="495.5,270.7 497.6,288.8 422.7,288.7 420.5,270.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="511.8,252 513.9,269.8 497.6,288.8 495.5,270.7 					"/>
+				</g>
+				<g>
+					<path fill="#8F586F" d="M437.2,251.8l75.9-0.1l-16.9,19.4l-76.9,0L437.2,251.8z M495.5,270.7l16.4-18.7l-74,0.1l-17.3,18.6
+						L495.5,270.7"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="511.8,252 495.5,270.7 420.5,270.7 437.8,252.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="496.1,271.1 498.2,289.1 421.5,289 419.3,271.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="513.1,251.6 515.1,269.5 498.2,289.1 496.1,271.1 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_445_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#955C73" points="492,276.5 493.6,292.3 493.5,292.4 491.9,276.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="490.8,276.9 492.5,292.6 385.9,292.7 384.1,277.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="384.1,277.1 385.9,292.7 351.9,332.3 350,316.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="490.8,276.9 460.6,316.4 350,316.3 384.1,277.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#C86876" points="490.8,276.9 492.5,292.6 462.4,332.6 460.6,316.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="460.6,316.4 462.4,332.6 351.9,332.3 350,316.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="461.4,316.8 463.1,333 350.7,332.7 348.8,316.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="491.9,276.7 493.5,292.4 463.1,333 461.4,316.8 					"/>
+				</g>
+				<g>
+					<path fill="#8F586F" d="M491.9,276.7l-30.5,40.1l-112.6-0.1l0.1-0.2l34.6-39.7l108.5-0.3L491.9,276.7z M384.1,277.1L350,316.3
+						l110.6,0.1l30.1-39.6L384.1,277.1"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="491.3,315.9 491.8,320.5 473.3,320.5 472.8,315.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="472.8,315.9 473.3,320.5 469.6,325.3 469.2,320.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="487.7,320.7 488.2,325.3 469.6,325.3 469.2,320.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="491.3,315.9 491.8,320.5 488.2,325.3 487.7,320.7 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M472.1,315.6l20.4,0l-4.1,5.5l-20.5,0L472.1,315.6z M487.7,320.7l3.6-4.8l-18.5,0l-3.7,4.8L487.7,320.7
+						"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="491.3,315.9 487.7,320.7 469.2,320.7 472.8,315.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="488.4,321.1 488.9,325.7 468.4,325.7 467.9,321.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="492.6,315.6 493,320.2 488.9,325.7 488.4,321.1 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_439_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855267" points="478.4,336.3 479.2,345.5 459,345.5 458.2,336.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="458.2,336.3 459,345.5 453.9,352.4 453,343.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="473.4,343.2 474.2,352.4 453.9,352.4 453,343.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="478.4,336.3 479.2,345.5 474.2,352.4 473.4,343.2 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M457.5,336l22.1,0l-5.6,7.6l-22.3,0L457.5,336z M473.4,343.2l5.1-6.9l-20.2,0l-5.2,6.9L473.4,343.2"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="478.4,336.3 473.4,343.2 453,343.2 458.2,336.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#855267" points="474.1,343.5 474.9,352.8 452.6,352.8 451.8,343.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="479.6,335.9 480.4,345.1 474.9,352.8 474.1,343.5 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="362.7,336.2 363.7,345.4 340,345.4 339,336.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="339,336.2 340,345.4 334.1,352.3 333,343 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="356.9,343 357.9,352.3 334.1,352.3 333,343 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="362.7,336.2 356.9,343 333,343 339,336.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="362.7,336.2 363.7,345.4 357.9,352.3 356.9,343 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="357.6,343.4 358.6,352.6 332.9,352.6 331.8,343.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="363.9,335.8 365,345 358.6,352.6 357.6,343.4 					"/>
+				</g>
+				<g>
+					<path fill="#8F586F" d="M338.3,335.8l25.6,0l-6.4,7.6l-25.8,0L338.3,335.8z M356.9,343l5.8-6.9l-23.8,0L333,343L356.9,343"/>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g>
+	<g id="XMLID_433_">
+		
+			<image overflow="visible" opacity="0.3" width="187" height="46" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALwAAAAvCAYAAABZu6BGAAAACXBIWXMAAAsSAAALEgHS3X78AAAA
+GXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAD95JREFUeNrsnQ1X2zwShTWynYQA
+pdvz7v//gbuHEiBftqXZe2fkJFAK9HMLlXrUOI7j2OTR6M5opIRQSy1/UZH6J6jljXKnfwrwtRHV
+8qsZ0e+FX37BxVfga3mRl3+jfgr/hBQ+CjaC1a+Va9brcBOu9b9PQ66vBV9+Aujy1Zv5VG6mlr+y
+5JzDOI5BVYXbpdr2UjXMdSFJ50EXKmHxDGg7Udntwj7uw05EY4yh3Wx0fXenNw65vhZ8+QmgC5iW
+i6urMJ6fC25QznBDdjPzcjO1/FUFgB8qAZ/jsQX0Kbcht63kNsv0WjnOHju8tyvnGEoVEVblI0DX
+OEZNKWlOW83jmMeu077v8+fPnyfwn4VefgB2ubq6ksViEWeAPOJGYruMsYmSYpLnbqaWdww7Lbu6
+kbPvH5w0GgFrIzlGVOH/QYwLbClJxrFRpcF74tQ7oCZCBoz4JOLoEDXr2CiMak5t4ssZDSGh5pub
+m3x3d5dfgr79RtitfvjwIc5mM2nbNhJ43FjUYWhEU9SAG8Lz5ombqeXvEOjxCLwZOwAAEw3GgXsA
+E9gdzWjjCZqC+D4axyDp5Fz2ip2KryjbUQZLKbYxwdqPI9DH+2z74uIi8Rz39/f5OQvfvvIeDsDj
+xPH8/Lzpuq6BFbfaCXgG/Xi9QXNsNIcG1xof3wx6o+rS/hXUi33LJDuUSsjthWICYeP9efSmADsu
+XzBK2L3JwJLDzqu1hwFnGHF0jzcOEDl9RLfRNI1cXl7aRxdL/2QEp30t7P9Cg+vOz+N8uYRoAeAi
+XRdji+vpcMYZ+psWd9ahtnitVTZr+BfTzbBz85uq5a8w9KqOvpoIJ9bRjLaWPp/qxfdJMeT+LxxE
+ifoG9Y/BPuIJK0HfoxnsG7iyOAxmn81HFKojz+dzShv5Hgt/gB1aPV60bdPO51AqsUXfArAJeZiB
+6jkumT72DFc9w+fMcJfwUQJUjDbWRsV9j5MmV8F/315rMfBOu0tzGEB7hGWHwaQCCM6ImGCRg2Se
+IDHNg43soAN4JewBkIctgNrQjc1oCwleA1wDYKnwidsMya23t7fhW4A/wP7x48eIrqKJbs3hYudZ
+IOQ5LPB5C1zXGQ5G1TNcyDywuo/qEoeuxuOb8T9Khf59a3k3c96rR69UBqE5bD+y8uGAhFrfYL6r
+hIStAft6HLTDPoAunZpnyANjbij9c4An249nDOWcnWUAL0/JmvYl2NFaGlx3E3NuJSUA3czRPs/w
++hIHnuPxHFDzcYl3njnwMqO8IfC8IddtFfJ37qs+EPE6BTnc2MG6i1t0Z8EMoQSDn3I3npxHiwMw
+aXbT69htsKP9dAzv0PLjuJE6HqfaA/+mjRDZ1EDD8NULfc7CMxITu5wjXGHCOwtNM8/SLHGB5wD6
+AvtYL3HwpRJ+ZSOAvBGz9GyFbbnRotDke0KhtbwB+fJIropb7WlbXcoY4NTvMJkEn72/Thae4Lsl
+hpYhzIxdUsoAaFp2SphAP5Etgg1hj7rFNuSzNoERkthS15iUei3wB+sOGUPPN44ZPQbkjAEPCYMj
+lvASLnDgh2BVPuDCPuBqCf85tqHnxYAXP791W1q89kr7O+H8RLk8juTRwBWfLboFF9fvwiieHCy7
+9f4ub0KBXss/ShmDvYDd+XGMyAt1/IbsZjsf2dJJOr1YviZpBN6u0MLjylvUTqHd8WkLkzISz3EX
+tOqE/srAF7kMLnEWJmvQ9UwtmuFWOXZ11ca/LxlTYLMYIrfjUbNPcua4r8Aew0lPUHoBdSPvuh1P
+BzzuixwCengexA2oK4apS+AorMV14F96LZi9WtJcXV0Fws6TozDW3jIiQ2dVLCKjS8qXQO0uruNL
+XTrwOsM1tX5zMjkmIUyxVq20vA/YPa6uLrtNsvjzA9TNCfxfNIRHpq9EZCRhY6DfWPTSYI3Ij/QB
+WJc0pu8jHzUkDkqNqXc984yOaJ9yPC4uLiyQn1KyUVRzWk0/hS4UPY8zzxiaxNtmIRyjMpNek4ct
+uJb3BbucQFvAtqhLUzhoi4M67Wsewf6YCx9cIuxCR9SeD+L20cOSKnBc4byK7plOhiN2wsEn1R6I
+jzhohAZKHH9tt9vT1AJ9ScMTdG9OOQvTBGLbRsY8saPosEM35ZFSDyilEi+NPl5w0nXpqcaT2gTe
+uIRRT20xgJkXJi5Vi7HjKLu0AGLy4aZGUAac5DEBJmPEswomb9MiMAScDiu2t4zQ4F1rPK4B+waw
+c98O5hzH6NDklOjoDuOYt3d3X4D+rKQpXq599kStHu9ag2sqdiPoenQv3qKldDNohdMNWlc0CSqx
+EYYQqqR5ew7qqcEqYWbqaW35aHLXX46+72D9jxa/DDrJ6WmZNVD0t8kVVYOcIGM/gV7js+7xeIdD
+bnHULc6B7cCEmTUs69acWoFzm/MI+Z3G2Sx/foawJ4GHnNEpJRP2vTgSOrU6dDVhjyvdFisurq20
+N0eVYaKHPcAkqcR9mlreGO0nsFv8e5IvbZGzc3VDp6X7borEPdpILWPtj6w69k1JkTaKWiIysORy
+jwOYH0DIV9j+jHff4DXWlTUADWu0EGqX/QgHF5yOzJrc7/enacIvZktqAd5yj3kCPMm8IfX05B5H
+7NyCW/c1aa2t3aTFRL1TMOinfqIOOL1px7REDKfRUQ4aWWoJWGCYmiPtuZA1wZ6KEfTOYRo1LTSE
+Y/bvaFZdZIIdHAlli8MO0IPBrjbnKTj0HEK9k6ybpHkLmbGXnIdBNa3Xa+bRaHilhdfpJm9vbxWO
+qyXF4GQpo/UES9oxx3UaFWMjoFVnTo3Bjtti7ownBp12hY+95toA3grzIi5TYjFirQcqrC4sguKR
+FfGInM5KzksSGykNnvh1bEAT7CURzEKPDrsUna4mYcyyG/Bi0F8X+Fdg5xZaY43Tb5oobCTDmNJ4
+v9mkkhr87ASQJyXNarUK8/lcF7NZSnBUcaWDJS0wm3NyUOE140+xtbkdOnniMiUJhZPcty/1YB1+
++oMljJ5a+Kj+fdKqt5C1NG5zG00PZpmDjZq6tWfAwkOGnt1YYNexjLKewt57YzFgd151Q+uuoncG
+vISVGOQCqy6U5SvT8Dnci6YNfUdtWjAYh33fn8L+agt/aul1t9tZuiXkzUiSE2cwmdvJm7GWvQ/2
+R8ANc2iX6e8lYahkdsqpp1sjM2/IqOth5JKy1GQKHgvszJcyqYLvnGMzYTQNTzSm6Rr+7cPn0xSO
+YYpT2HdHCcOqNJxMHbjH59+Fg3bXFWBa4bNX2A/LDifWYd8BzD0M8KhQIJwB9RrYv6bh7Zoha5hu
+GZhUH7oujDmzX7MpVVBsPWPzuDvCTrfWrL9lRapHnfT0cyvwb0q3xxJ2hDBnCLqDfaZmX3gmr8XX
+adGzeIzSIzIiD+Lr4mkAY9HqPnEjHJPAcK4p1LjxPBmldr+3qmbhDXxwdGeRmSPse4M9MsVLR3J6
+fX2dXwP7VyXN9MZp5sjHjx/NcGcWtNI2tZHT+1IYY4TkSZY94P+aE5H/5Rlr+XOVjE/Hg/myODtl
+agy5VaaC++AP4Kcv55NRVadIzWG6Mvw4bUtQjvZuclwZjRmLVd8q4dawPsTUATrOtRY6q0Lo+VjA
+D3IfrCFA7ihqDCZjzLJ/B+zPSRo5hR5wK2eScHY4Qe/aznMfywxa/j00JzRA/8xY+XlTxTIMg89F
+FXy/Y8NJbcr/ZmV3GzxhvYQlCbiljyyEeVNTdqxavruHqS35y7T8MMFOiF22EGa9x/H3UsBXg1+Y
+FEZps0GLQY0be5+mnWrmCOtAzU4Z8z2wv2ThD9CXJRDsOSROlqVIHnJY4IrnmUtxLB4sx5EqQ28L
++LJeTJtstQnK06ahn5qlydEijhI5TznaGMtMPBv2zGSOrygzKwtTNOKkTBLGUnuxD9JFabFdqqje
+GvxSrDhkDY4B2BxI0mlk1SBHo9oPqj2UxKApjXRQqdm/B/bngP+aCFFY/FDmDIZ/OOoQPol8Oguy
+rCL9LQOfAHvsOgLPCT+hSU3jA6HmxLp84RROt+Y256HMcKOe7zh/2TsKHU3QcPQzWL7LxkdH5dad
+UV0Fj7EX2WKyhnnt7siqMBgC0HMPe84GM2ijYw8J8yj0+M2wvwT8s+CzHXPZs/+Ga+UyaBYpreVN
+O6xcfuXi4oIToRvzOm1w3dJzGWOHni8TgWz+so+9lJC0JecC+qFEnkePwnAQST2uHgz0qdIhvaNs
+QcPgLCYmgwF0JoJFZkoOo+YRbkBqpTXHl4NKPwr7a4F/Cnypbuj7Kxxw5Gors9ksUNho1hKIYeag
+DSo2BfBjaq/lrofhKIMllTSBTXE+C+xisOOMtPL3rMp8GWY9ZhvB76UB6PAEU06m/wcdUp/7POyG
+0xFU/RH22u98X4X9HYYjH0VtDkmEMuXBONKWFqA2n9TCjI0nEwYL1eF1d1LhjOIUd4yfE3j1gaSj
+lKFeB/A8R0x5wAnH1EQmgFlwZBgGy4t5zWpivwP4Wt5pdJILlZb1HMMUgPOYuiZleFGVuVN7cyxt
+dpPJlzb4qJPPNZVAkNeTdCna/ZZJYXhcZ7UwI5xZZTx9yJJHrtA4wLYD8sxBz5ubm6dy2n/Y0Fbg
+a3lo6ul9crFSgzxanrqolsRB3Znm9skdwTS7ltClD7BPKww8Su2VEoq08OMWJ94l6HUmfXVNM0K0
+p904mkU/WRQ1/EzQK/C1PFlo4TNXbVTNsZkl2PDB8qYEjmXIrVl1H0YfAPlMPHPWfTobYNIpP2bD
+2DpUURloyhZTx3n24tmRUC3DOMmXJ1b//SXSuQJfywOwttutynKZmUcFrkc4kEMbIiRMbHyChM1O
+6j3ZyxIHo6+oV2Yp0fkUhhV9hTDs3yp7hpx3kXInxr6MvI6bzSb/bI1ega/lmyM1ZY3GlDmLSGNv
+6zear2oSZ8Dzva0jerLCNdU+k8jEl9bge2z9R8KfY+jRabCXGLqRW31aj2P6WZGXCnwtP2TtqaW7
+rmOmbGqkGbhYKVf7b5gZSe1NaZIt3SDaQor2LqZSKVODR3i3A3T+gFYy4CiLqzP3BdIl9et1Gtbr
+fOPZk7/Fqlfga3lW1lBmTJmysfNf3JBpqWrGzONk2XM8WQ3SOgKDPuYURqbuShpiHtlwcEiCXMp3
+gP13W/XTUn+noJYHQZppA86khSYXi0X5UQ94sZpTHGNqYjOGJg0SSvTGJ+73om2vQ+5BO6x6Q8s+
+9qlP6DFYucCp/j9hrxa+lqes/BeZstD02g5DtuVa2o6hx5Ile2wgYumVQbWFxoGrm8e99njvbrfL
+q9XqVb+/9FtbdC21PMHFcSVp1PPLSxmXy5Nf4eOPEahNi4J3qlv+uh4gb9drvV+tmF71S2PqFfha
+fjX4h23/aVJLBbfMMuYO/ucJf+BPAb0CX8uPcCKvcX7/JNAr8LX8KmZqYmEttfwp5X8CDACsRaGS
+YZlFeQAAAABJRU5ErkJggg==" transform="matrix(1 0 0 1 159.509 225.5963)">
+		</image>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#E5E4E8" points="180.6,225.6 180.9,227.6 173.8,233.7 173.5,231.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCE" points="333.7,225.4 334,227.4 180.9,227.6 180.6,225.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="314.6,231.6 314.9,233.6 173.8,233.7 173.5,231.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCE" points="313.3,231.9 313.6,234 172.5,234 172.2,232 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="333.7,225.4 334,227.4 322.2,238.6 321.9,236.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="321.9,236.5 322.2,238.6 317.4,238.6 317.1,236.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="335,225 335.3,227.1 322.7,238.9 322.4,236.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCBCE" points="322.4,236.8 322.7,238.9 318,238.9 317.7,236.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="314.6,231.6 314.9,233.6 300.5,247.1 300.2,245 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="308,245 308.3,247.1 300.5,247.1 300.2,245 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="317.1,236.5 317.4,238.6 308.3,247.1 308,245 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E6E6" points="333.7,225.4 321.9,236.5 317.1,236.5 308,245 300.2,245 314.6,231.6 173.5,231.6 180.6,225.6 
+											"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="317.7,236.8 318,238.9 308.9,247.4 308.6,245.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCBCE" points="308.6,245.3 308.9,247.4 299.2,247.4 298.9,245.3 					"/>
+				</g>
+				<g>
+					<path fill="#DDDCE0" d="M180.1,225.2L335,225l-12.6,11.8l-4.8,0l-9,8.5l-9.7,0l14.4-13.4L172.2,232L180.1,225.2z M321.9,236.5
+						l11.8-11.1l-153.1,0.2l-7.1,6.1l141.1-0.1L300.2,245l7.8,0l9-8.5L321.9,236.5"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_429_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="233.2,220.2 233.8,224.8 227.5,224.8 227,220.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="227,220.2 227.5,224.8 223.4,229.2 222.8,224.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="229.1,224.6 229.7,229.2 223.4,229.2 222.8,224.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="233.2,220.2 229.1,224.6 222.8,224.6 227,220.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="233.2,220.2 233.8,224.8 229.7,229.2 229.1,224.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="229.7,224.9 230.3,229.6 222.2,229.6 221.6,224.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="234.4,219.9 235,224.5 230.3,229.6 229.7,224.9 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M226.4,219.9l8.1,0l-4.8,5.1l-8.1,0L226.4,219.9z M229.1,224.6l4.1-4.4l-6.2,0l-4.1,4.4L229.1,224.6"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_425_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="242.3,220.2 242.9,224.9 235.2,224.9 234.7,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="234.7,220.3 235.2,224.9 231.1,229.3 230.5,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="238.2,224.7 238.7,229.3 231.1,229.3 230.5,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="242.3,220.2 238.2,224.7 230.5,224.7 234.7,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="242.3,220.2 242.9,224.9 238.7,229.3 238.2,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="238.8,225 239.3,229.6 229.8,229.6 229.2,225 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="243.6,219.9 244.1,224.5 239.3,229.6 238.8,225 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M234.1,219.9l9.5,0l-4.8,5.1l-9.5,0L234.1,219.9z M238.2,224.7l4.1-4.4l-7.6,0l-4.2,4.4L238.2,224.7"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_421_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="251.5,220.2 252.1,224.8 244.4,224.8 243.8,220.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="243.8,220.2 244.4,224.8 240.2,229.2 239.7,224.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="247.4,224.6 248,229.2 240.2,229.2 239.7,224.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="251.5,220.2 252.1,224.8 248,229.2 247.4,224.6 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M243.2,219.9l9.6,0l-4.7,5.1l-9.6,0L243.2,219.9z M247.4,224.6l4.1-4.4l-7.7,0l-4.1,4.4L247.4,224.6"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="251.5,220.2 247.4,224.6 239.7,224.6 243.8,220.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="248,224.9 248.6,229.5 239,229.5 238.4,224.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="252.8,219.9 253.3,224.5 248.6,229.5 248,224.9 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_417_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="270.2,220.3 270.8,224.9 253.4,224.9 252.8,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="252.8,220.3 253.4,224.9 249.2,229.3 248.6,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="266.1,224.7 266.7,229.3 249.2,229.3 248.6,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="270.2,220.3 266.1,224.7 248.6,224.7 252.8,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="270.2,220.3 270.8,224.9 266.7,229.3 266.1,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="266.7,225 267.3,229.6 247.9,229.6 247.4,225 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="271.5,219.9 272.1,224.5 267.3,229.6 266.7,225 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M252.2,219.9l19.3,0l-4.8,5.1l-19.4,0L252.2,219.9z M266.1,224.7l4.1-4.4l-17.4,0l-4.2,4.4L266.1,224.7
+						"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="317.4,220.3 318,224.9 303.9,224.9 303.3,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="303.3,220.3 303.9,224.9 299.7,229.4 299.1,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="313.2,224.7 313.8,229.4 299.7,229.4 299.1,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="317.4,220.3 313.2,224.7 299.1,224.7 303.3,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="317.4,220.3 318,224.9 313.8,229.4 313.2,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="313.9,225.1 314.4,229.7 298.4,229.7 297.9,225.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="318.7,219.9 319.2,224.5 314.4,229.7 313.9,225.1 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M302.7,219.9l16,0l-4.8,5.1l-16,0L302.7,219.9z M313.2,224.7l4.2-4.5l-14.1,0l-4.2,4.4L313.2,224.7"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_411_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="333.5,220.2 334.1,224.9 319.4,224.9 318.8,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="318.8,220.3 319.4,224.9 315.2,229.3 314.6,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="329.4,224.7 330,229.3 315.2,229.3 314.6,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="333.5,220.2 329.4,224.7 314.6,224.7 318.8,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="333.5,220.2 334.1,224.9 330,229.3 329.4,224.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="330,225 330.6,229.6 314,229.6 313.4,225 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="334.8,219.9 335.4,224.5 330.6,229.6 330,225 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M318.2,219.9l16.6,0L330,225l-16.7,0L318.2,219.9z M329.4,224.7l4.1-4.4l-14.7,0l-4.2,4.4L329.4,224.7"
+						/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_407_">
+		
+			<image overflow="visible" opacity="0.41" width="67" height="60" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEQAAAA9CAYAAAAUPs+7AAAACXBIWXMAAAsSAAALEgHS3X78AAAA
+GXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAADqdJREFUeNrsW2l32zgSRDd46LJl
+x0lm3vz/fzUfdr7s7L5J5EsnRQC91Q3KpuNLvrPvRYksmSIpoFBdXQDazv16/Ho89KCfrB1v0R75
+4fWnBeQKhLIsaTQaUUqJRESfrns+uX1EpE/p3kvhCpGFyIW7kH3AKT4KjIEb0KgYcVM3XBQFT6dT
+n0JAF4QiESsg1vI9QemBAKQJN3GOvSSWKkmQFHxIzJzm83l6CJTiA1hhjJhWE39QjP1qPCi6dpRM
+5D3AUICMKdq7J90coKCbHcUSuRADYKYphUM+DAAkgIVhuVzeC8q7A2JgTKZ+XI/KJG1VeF975hod
+GDjmEkNcUBJPNswKyL6giP4XhQT/k5QukviWmZpIqfGBm9S2DZioJ+9A+VBArsEox5UERE1VDj27
+MegwRi/G6PsAp1UAomASdhYu+vR76GYXY+ySSxzxssX9NmDL2jteMPmlsLh1SnJ8fCwARDrGykcA
+QjWeh1XlJ/WwdABDijhh7w5AgyN8NAUPDtD1Mc4doN0Vade6EMujL/eJR79PCe8Sk2ud8MZRWuKE
+S5xSEqgiro6ltDE1TcAX0fKDALFOVd77iY58bAeppDF5mQrxJ0TFCZp0gnYdI0oOce4QwVKBGN5R
+9y8zgO6kBu0ogjfgBq4N+KUBnOgvX+CTKn8eW7w2ZeSmCORHbhj+dOsPEVVSkeTxuNgOh1Xt/ZBZ
+wAY+xuh+RUt/wylfyUBxhzg2QvsRNk51hHfMkHssAnXpSJHACRHPFkKyBo6XokwjUdasES4IGynY
+EYdmgq8b49R/uR/DpngP3Tg4OPDj0ahEDAxFieLcEZ6fnYHh/kAHFBQFZAoAhkooNNOjmbzD4RFl
+FeOHk6AswHMBYdVrG8jQpTIOIeOBAiPnWGL+CB+SQwW6MR6PywKCCec1lpSOwIITMnbQ72j47zjx
+NwzRCa5QTRngtXRZSekBLCT/6AhizkO1w61wSUKvV9Y/I06OOeTh5BimBPGaTG5up97iLcGAbCCj
+ctG2bQ1kRnh/iIxyjM8+oxVf0ZSvOPMrRvEzqH2MTiHTuLprl1nOK5W4ExEx12FiCiHVC3CoIesj
+RTAPABGyjTQupS1uFAK7uPDzNHMzede0q6EymUz8cDCE4eIBGppDRUUU7FDdQEO/oBOf8HqEpk3Q
+qaFeSn120IPZduclVDtiJzUB12jYLEGOBSYDc3z3EvGzBkMbUK8Fa9N7OlVLsQdl6UfDYUm+RBql
+CTg91bBApwGC+4LmfBHVDVI9oXEHhqbbwuWU+5Bt73cmWshg9JUd+OoVXi/xeoHrz3H8ArK6iJJW
+cMJN9D64GN8NkOsUi1ChEGqI6IiYDjFan+APkGLpC875Ajp/AtkVpAmaNlTdADDeXfuP+7S0b6ik
+A0RTKnwHLXDoHN9xivvPcGwGqM6gpZewrasQQtMsl/Hs7Cz1rn9bQHYpth0O65p5SJpKHR0ZGA5g
+kOqHnGj4oAMaRiqiO2b4PZYCqGOEgYF7tQB2jaMLHLkAp05xwne8/55ETkGyC0A8B9irpmlagBG6
+6988y9BONybIKtrRxCAKQsU58xhghmioQECdasYBfh8BlJ2I7gPGlU9HWERcG9BR0ws8z/HBDOB8
+gyZ9g9zq81RBQjCtxMsWgxV6YL5pyGRrrroBv4GcjxQrCAWaomtwo+Y5uidEVEEi6IaTuqcZ+4Nh
+PozMc+AeK9x/jsvOkKm+49g3gPUNhu0UdzqPnJbb7XbTblplR3xsoYhfWzd8jDriI2F/gA+OTUA1
+xeZXZYplFJ2zULbVvteOx2a20hPQrdPMIRkMfDTbgQEx1ZwKgGiO5wppf9sLFXkIFH413ZhMiu1k
+UjmIKG56qL4CfuBzB8QX8x5C8CBq2x3sOfwG5jY/hIrbgx06ygH32FioEELCITSybnyzV6JTzTSc
+0hKANEiz7T5gvEbI3LbmkFS8Tik7TzNeCB01Yho6h3g/wmtl3y2w19eLQPuFirIDoULmSJFeCVlE
+dqGiYKhuyAWs6mIbwma7Xrez2Sz1AHFvBcjd1lzErLmFCanfIE2xJ7sUSwqa+Q2dzT4LDAsVXItQ
+kTMVUrzPoYJUi8E4SzHOuW3XLcRjdnHxYFZ5rZC5Zc3B41GCNVfd6AQUKbYDw44RNIU683XLb+wT
+KpjWQzdEMGeXhbIAB0/hbxQMTbEzTFLAFjePzCsH3aivwRC356r7sxnyiDXPuiHyGZ033UAqHOVZ
+LL1dioWexEDL5F2zLsv22xPBeC4ge1pzsCPryBSjqNZcU2z5LN3YN8UKUmzcP8W+RsjcTLGw5phR
+w5onDZVra5514xOZKYMfcTLQRR9jxn5gvEuKfQ2GvMSaP0c3rlIsPZRiU7pkzGihYU9KsS8F5H2t
++Tuk2JcA8v7W/B1S7HM15L2t+Y0UK4+k2ADd0BRbPSPFPpchP66amzUXtebibllzqL9Zc3quNb+Z
+YlfkXAeGhoh8Bwh40ilYeZkCryKF7cr7dvZCZuwLyHtZc9dLsVcLPgB9AVack4UKtAPsAFAAR1RE
+V0l8g0dYnl7twrl7vmvvkojiJ7DmN7QD9wc74DkQCppmlSEA4yyJplt3gTsumNJaF42jT6kuairq
+whNf7wG/pCSieO6q+ZU1d31rruui8lRr3gdE97dt542ymC6yTacFstnSNpzAHmQVAdq+EipDRRyP
+YprSVF6jJKJ4xJrzcDDQMoUBRmSCL3pta36jlAHgmu+gLt1md2rT/K1+ZnEhrmDVJ2bdx6o8aDsY
+DNJrlUTcyxANFQBSomc1xYgUagbsE4ZBQTC/obpxjzV3TwBDbjAki2O0kga8130myQ63Rid1MxwE
+ocp0hnXvpdAtOumXROTdK1xfAGDhlv3+JRHFfUKqmSWGUCJqBqKOU9nB8BgqoNAMBYd069FZIwdK
+KhzbgfGUUHG9HbhuC9e2H9gAJth+McerngTTJhph7HVTCp0lBazbyrpZEoFx0ZIIiDNtcHjlHS8J
+Ty3D2TxQEnEnIKAgHyKzgI0VQmUIMdHaDYX1uNthOxZLvbpjDM9GrsjlC9oRcj1zRHsCYoKaW5bB
+QC+hRTLEr4e4i7JFtzcP0H2ED6mdF62/cn12dG90q5/N8rOtquG8S1x37qwkooqlCyE1bRij+Ut8
+/Ohmd9INv+22YO/NlaJfYzBkYrvzojv0CoQM0LAcIlnJ0m738SmPq817CxPMXfQAgYs2GVS3a5vY
+OlWY4LiCEfFZpjr9UN5h9UNWCKD3grHT+Q8sv7habBNQWvzYlIE3RYChcn+EP92fD4oqeliCkxWU
+kX0CIEysWWPQbSYBBNUKRGduzW5q7q6yijypsnHXm938Q01Zm0fZMtUgb9UTwhZia1uXGULKpRA3
+B9IoSso067jNf1SAcQx02oiXBSd00DsfGjXSoS/8cidDDvDvUE0ohLlwiRHJHt+rpQk+l+tArDSG
+STZoNGsaRMN8twv7jDLPq018xVhDI6KlEd8UrRzCNr8xQhloMId6lUU3v49ymQgGiLa2kKSK6+Br
+ROa4sBatD2HnU+Rc/nmHFSnu2FGnrnVaoiEdha0QBZ/CPdomctXFvC7nFZniz6t57XazNT+6rqBM
+XGcnHFl9SJGfcL8QAMl65TVUhW7MxSxcJDNsTVmmVUNKHPOuk5tcnBXQZC8bM8Q3BegWIGCTDXfC
+YCFSEYve6Kc2GsMFG60f64KNzUDLXPok3Lvzk0KGbltHMmMnWtth7BjaZBLiTbluRCsWtVqxb/46
+229VAMraoOxV0dXek5ZFYLKI/myjxJBUY3ie/qPbvo+l3YB/CekaNi/GVEFdZaN2GfF31u3FN073
+S23yhtHSUdpZRLnq4978yDbDDJcRRKxqSEfVZssQUpsfiYKRlxPMlyOMBd9NfUByFUBmNMQhVwLg
+Vc3GAietkksbqxOBMduU5V5lmXLuzqXlVo7Ko0ApNizFSnXECvzEZqBzFVfcqqvyEbKx2XuGf68T
+IckFL4WaPBxXs4dJJDKL4WE+B2EjOzd8gx3AAbpj4WKra5AImwfhHrkkAjqCey3h6poWs2Md77vW
+Tu5Ku6J+XxFPcYvGxFWiSsetxbRgJWbCyEJF2SE517oXl81bnxPUjkqrFSE5yBpl5svnQhrZlVrp
+18XeOkvaaRzacok26Qw5l0QIndriUnJIv7SSotCSiDCbzeSutZM7AdHJj/p9tbjrGKGaIUJZmqQz
+0JhKAWPY6I0XvytsedlyhMLBmM8npHnVjbxsqOZKpwJWO1K56wretmMLd7KVutU1vQbhLN/Ron/Q
+xG+i720xSRkT1gl60KsC2Hu2K53PD2px41qXyeptGDSbIqLR0RMOkLJUq0Kf81cLt5buMtU8kFff
+M+QEf8M2mymtblVn8SYxbgvFGmVbT9wtKqkfarTZGRD3HZ//F6f/AzBABbnMVQBhg5l76BXM7A+I
+/lBQ1O+P3CjVgzrEASYGKbBoLRtmBWDRqxWXgIFcU80yTKUnhn6xxoMXyyyqGdYkzGFsKyLPnbIA
+my3Az62VU5FcdBVEYIj8A/BOEU+w7vttURT7zDNWbiV/bf5y7t+3hOI1/96G6rpmiHn0ZanTFQhZ
+oY64IHMpMFjwQDq5I7PiyDKddxdb+RDzH1n0RTXkLIqcxiyoypzmNQpmflxdess/OKKmaXTxRng6
+hSjwujRbZH8VofOXjYhljIFohqP8yS5koO8t3jR4t0SkLYXTJcCYI5ksFCgtp4KQPrqb99SNKnlD
+QKRbpSNbxGnbJs/uKxBFtjAemKvL7QyX/XcCGwLetWKViHCoUVZa4q3v1+v1bmvz0VX5j/qLqntB
+eVKG426OTIBDOJI6a44BcoxZcbnlKrY9MOJ7FMy8CSj7ZjgbbzYXIggYIW6TxCLFNYdlOY+FK+IP
+O3mPMpzcz/m4ms0iw/HXwVdqT1pCluDdHyfuMpyuvyDErKP6WsRC1Hn87f6WntfYe/PqZwXE3bFI
+/VCGk0f2YOSpX/r/8HjOwtOvx6/HKz/+J8AAFAalGszwlcsAAAAASUVORK5CYII=" transform="matrix(1 0 0 1 442.7828 190.8701)">
+		</image>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#CECDD0" points="494.8,189.3 495,191.3 474.1,191.4 473.9,189.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="494.8,189.3 495,191.3 473,222.3 472.8,220.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="496,189 496.2,191 474.2,221.9 474,219.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="473.9,189.3 474.1,191.4 450.1,224.4 449.9,222.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD0" points="490.4,220.3 490.6,222.4 473,222.3 472.8,220.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D6D6D6" points="471.3,222.3 471.5,224.4 450.1,224.4 449.9,222.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD0" points="496,220.3 496.2,222.4 490.6,222.4 490.4,220.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#D6D6D6" points="485.4,222.3 485.6,224.4 471.5,224.4 471.3,222.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD0" points="472,222.7 472.2,224.7 448.8,224.8 448.6,222.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD0" points="484.1,222.7 484.3,224.8 472.2,224.7 472,222.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="485.4,222.3 485.6,224.4 481.2,230.6 481,228.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="496,220.3 496.2,222.4 490.5,230.6 490.3,228.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D6D6D6" points="490.3,228.5 490.5,230.6 481.2,230.6 481,228.5 					"/>
+				</g>
+				<g>
+					<path fill="#DFDEE2" d="M491.6,219.9l5.6,0l-6.2,8.9l-11.2,0l4.3-6.2l-12.2,0l-23.3,0.1l24.6-33.7l22.7,0l-22,30.9L491.6,219.9
+						z M490.3,228.5l5.7-8.2l-5.7,0l-17.6-0.1l22-30.9l-20.8,0l-24.1,33l21.3,0l14.2-0.1l-4.3,6.2L490.3,228.5"/>
+				</g>
+				<g>
+					<polygon fill="#E8E8E8" points="494.8,189.3 472.8,220.2 490.4,220.2 496,220.3 490.3,228.5 481,228.5 485.4,222.3 
+						471.3,222.3 449.9,222.4 473.9,189.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD0" points="491,228.9 491.2,231 480,230.9 479.8,228.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="497.2,219.9 497.4,222 491.2,231 491,228.9 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="483.2,189.6 483.6,193.8 471.4,193.8 471,189.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="471,189.6 471.4,193.8 467.4,199.5 467,195.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="479.2,195.3 479.6,199.5 467.4,199.5 467,195.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="483.2,189.6 479.2,195.3 467,195.3 471,189.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="483.2,189.6 483.6,193.8 479.6,199.5 479.2,195.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="479.9,195.6 480.3,199.8 466.1,199.8 465.7,195.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="484.4,189.3 484.8,193.5 480.3,199.8 479.9,195.6 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M470.3,189.3l14.1,0l-4.5,6.3l-14.2,0L470.3,189.3z M479.2,195.3l4-5.6l-12.2,0l-4,5.6L479.2,195.3"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="479.1,195.3 479.5,199.5 467.3,199.5 466.9,195.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="466.9,195.3 467.3,199.5 464.8,203 464.4,198.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="476.6,198.8 477,203 464.8,203 464.4,198.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="479.1,195.3 479.5,199.5 477,203 476.6,198.8 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M466.2,195l14.1,0l-2.9,4.2l-14.2,0L466.2,195z M476.6,198.8l2.5-3.5l-12.2,0l-2.5,3.5L476.6,198.8"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="479.1,195.3 476.6,198.8 464.4,198.8 466.9,195.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="477.4,199.1 477.8,203.4 463.6,203.3 463.2,199.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="480.3,195 480.7,199.2 477.8,203.4 477.4,199.1 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="465,213.3 465.4,217.5 453.2,217.5 452.8,213.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="452.8,213.3 453.2,217.5 449.7,222.5 449.3,218.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="461.5,218.2 461.9,222.5 449.7,222.5 449.3,218.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="465,213.3 461.5,218.2 449.3,218.2 452.8,213.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="465,213.3 465.4,217.5 461.9,222.5 461.5,218.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="462.3,218.6 462.7,222.8 448.5,222.8 448.1,218.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="466.2,213 466.6,217.2 462.7,222.8 462.3,218.6 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M452.1,213l14.1,0l-4,5.6l-14.2,0L452.1,213z M461.5,218.2l3.5-4.9l-12.2,0l-3.5,4.9L461.5,218.2"/>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g>
+	<g id="XMLID_391_">
+		
+			<image overflow="visible" opacity="0.26" width="579" height="96" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAkQAAABhCAYAAAA3Hr72AAAACXBIWXMAAAsSAAALEgHS3X78AAAA
+GXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAQhNJREFUeNrsfQljG7euNcHZJHlP
+k5vu937v//+m926bNs1ix4t2zQzx4YAcaWRLXmVHtolW0WotQw5xCBwcGBMtWrRo0aJFi/bKjeIh
+iBYtWrRo0aI9U6zCERBFixYtWrRo0V4q6KF7ACJ+CFiKgChatGjRokWL9j0BEG7ToVy6e3tUdTpU
+1zUxMxXMJi8K4jw3cn/xB0SGZjMzm055ittEnCQJp5MJT/p9PvVgiFugiO/yhaJFixYtWrRo0R4b
+BOHa7gn4KQTspFVlKUmsoJokzTJr0jQxdW0F5JC1Vi9sLQARtQARk3PGOce4wEySOCCpuqrqGXMt
+j7tuWbrZxYX7chUgRUAULVq0aNGiRXtyHKBRIAFBNgXgMSbpZlkqYCcRxJMmRKkglUzu67WgHzye
+EPnwj2mBocU7EhsO5lwt92t5USnPzOR+yXVdEnNZCkQ6G4+r4XBYy3NuHSiKgChatGjRokV7fcCH
+ngIHvJVL7+CARlmmIKgoCoCgXG7n1piCnSkE8eQJmUJwSi7QpxC0UggGyvB6+XoWyEe+JbUhEflY
+j/yLPBoD5NQCi0p5yVRuj+XBiTw1lgfHztrxbDabnJ+fzyaTSYXXrgJFERBFixYtWrRoLx8M2cPD
+Q6SoLPg5chHkwbSKn7MpQ4rLVhWlAmzY2tQACNm0I/CmK5/Wk5fskOGuIJ2ewBN9XJBORx4XcERy
+MYgWWQqA6OoHAA1p6EgAEWtkyAAIGTOSy0Ce6ssTF/IeF7VzF9NJOZwOppPz6Xm5ChRFQBQtWrRo
+0aK9XCBEB+bAUofSfD9PNULDjGjNnKNzmZ+zsQ+X92R8ljMpOQE5VsAP0Q4yZ4JE9uUle0S8K/fl
+MYAh0yVcAxCxQRRJsJRJNGV2DeoK4KaSv0d0aCKPDAVo9eWPzuTJE7l/7ORS13w6nU0vLoYX48lk
+AlC0lD5L43yJFi1atGjRXiYg2t3dTbp5N88SKiixHTK2kxB7sGFJwQY5R5tGQwwwJoCI/OcUcqMj
+n7Ur9/fk6QO5PsQ1vqK8UgGRAJeOwLJCnpPvh5QZp/KcNZozW/kZ+inynwAbqhAlYkMTQWIjud+X
+50/luS/yxzvWUGoS+YA8q8kc1GmausFgwBEQ3Q1dr7ptzObEoDge5mjRokWLtmFDFVfS6/XyNEt7
+qYIR2hfAsS/urEfMiMKkcrG+ZGuTaIjhMEn5P2Qy0hSY6cntXQYIYgVE+B5y4R25j/QZQJOAIMoV
+CAGfEPhDCog8wFqDu+R/50GRqQhpMzYCiszQABAZs6vgithZMjPBgBMy6dRUphyYQR18O0dAdD0Q
+8qHGg4N5ztU5p8+19Q7G/T6fPQzU8C3AUQRN0aJFixbt1j7sQIBEN8vyJE17gigOxIn8IIDjnVx+
+IBYwQtRDNRcpcVlJyhuERBTeEvwfzgwrH6jLjPQYAIrZAzgS4ITIkOcMUYgIeSJ10kSGTEA8ayNE
+/l9WUGTIk6sFFMmHjxWEITJEBkTqkbzqQl54Lvf7meXkSJ48bb1fBEQrRvIHGUS7s5Nwt5t20zSx
+SZJyliHfapl9lR/0Dkya1t2icJ00dQn0D+4QdLxOVGoFyFonLBWBUrRo0aJFu4xGrGzks9wiRWb2
+xcO8k+uf5PGfBSj8KC85AjAhnzprgMfGvwfcmoAhAC5EfTqBH9QNQEWAEAMoZfJKwSIcKsr89zdL
+VXB8k7Nrawwh2FXIP3kAeTOQqnEcApFbwJdL5Vnb29uj034/AqJ1UaGDgwPbA2ouipxlRiXOdWRU
+fQkg6cBCCEpRKKVpadO0stYCfTom4rvMFLLW2DznvCUqtQSy6sTZWWlKmgE0ATAZgKbpdOrOzsAV
+W6+nEC1atGjRXqcv6/V6qe31CpPnAnrojezmfxQP97s4nt/F0wAYyb4fFV5KXE4eAw3xImWWGE/i
+zoxPncGX4nMzeU1K87QY0SIitBxqut3HLQEjxJScwKgsRKhSAUipfhfDlsX9rnKcERC1Djzyrd1u
+N5cR6AjI2RGMsidjtCfAZUeuO0oOY4G71rpG70AGc4bbxucumW4LUECMJ5D7ZWzkWkWlLoOsWgBP
+nriEC/kPgMnUjkjZ9PI9q/F43IhMuTh80aJFi/bqzYJELZc8yzIAniO5vBcg8AvAkDyPCwDRkTzW
+88RlY/nxKs5BrIaTs+SjPmkAR02V26VI0EMxmGkCBUibwUeDZD2Th6fyuahAQ1l+KZ9bi8/lUb/P
+ERCtGDSUJfbyXpZS2rXE+zJMb2SsfpAD+kYmEghgKBXMyKcyccARhtMSP4AiOdgaJTK3jBKRH7Ym
+vOeMtfUVkGWR9yR5FTnrAVMpwHaap+lkZ2dn4pybipXmBjnyaNGiRYv2CvzYwYHtdDp5kaY98pVc
+b8Wf/CSXX8VB/Cr3f5bXvWPD+z5lpRiA6NHwEGIxczKJT4XRUiToPh/MK0CQelToVcvblwyfbMxQ
+rs/EN38znlyN2wNinkC9eio+9TL/NwKiMEi2a1NKNDW2K1j2B7n86JE0vRfw8saACEYmZw3rsYAT
+WwqqUUDkUScpIKKgbuWPMtFivBvW/ZU4EZMnglXkNRSmqrRJNA0gSyNHJqFS3mIs7z9IrL0oiuJC
+twPWuvF4HNNn0aJFi/aK/diRMUkvy3LKsq74DwCetyEa9AuDO4RIEatwNIASuDQNfwgMnafQJLxv
+JOhKOqwVCQoq1VTDX4a2HRO5HoE3JI+dyP2PcvlHfuIXuX8qqGlYM8/MQpgxlt237cgcUdEtEsqU
+CS/AhwCA3svlV0woNgqI9kK+tYkQlaBFsw/BzeTRGgMTjqzSpFnLGblBRbRqepDnigVRKUW10zCg
+M/nLSgaxIgtgRABefZm2J/geqbVsiqJMXVp2xp361JzGgYwWLVq0V7qpzzudLCON+uzLxl6Aj27q
+fzGeSP0T62OM5xowlDwgSvMUthT98RduKslCWoxrQjDC01ZCgIKHqCaTH3Uqf/hVwZAxf8n9T9Al
+EjA0mNX1FD1gTYwQXbXeXo9sboGUsyApvqsomsyhHK5DhB6DcFQWJg8iOzIQSHFRxT664zQGpGqf
+mhdNycuOJ54937DmqRUzMitEpTzAEhxVEqnyZimgyIf/DH8LoAwN7EYysYdplo6TvYRO+xEQRYsW
+LdprBEQgURNI1Fmxa419w35D/wst0mRvvR+jbvBj2wyG2MyzJ0YjP4Y0AyPABz5RxRdxv9SLj/YA
+DEGMUcGQ3D4T1/pNft1XeSM0uv8i/vNrxe5sUpbj4XBYjUYjFwHRyqOvpfREDr11TcN4t6aJ3gCU
+GJ6EtJjGdWiuecB1izdkVfMAoIVR2mc65CXIMwOGuwdKbYGpK6JS+hksnydgSEEXkC/RWB4793oR
+NJavdYr3TZgT+Y8q6H724zhGixbtwZGGaM9szJRE3dnNsyLbYavl9P8iRIbI/CaQ4hdBFQBHR54H
+q1Ve2x8Z8lwg+FtkSiY+8qOZk4amMvVEadBL9D585FAeG8jtc+NbdgTuEJ8ax6e144vRbDocDAbT
+0OD1CsUkAiLMij6BiwOtzIaZDtIV0lNnyoxnRZ45LyYSANEinMdawqdgiLzI1A4rCuck3O949U3/
+902M6JKoFMCRAyJmCik0j4wxAQYKzAIJjubfQcVFOa5i0aJFuyfwuU+Jc7QtsZ2dHa2MztNExRfF
+jbwTv/Cz8STqX+T+e2YtDNprgSFrtjcyhNgQipPKAHy0J5k4SER9BuLsBpodMQzRxYncH7MXYBwj
+VSauGL5SPDpfyC+8UCFG5qGreTiZlpPBaNB0u3cREK2xkRlxURcuo0zQqB0JYjnzCp7K3TkDEGF/
+rGzTUYWXuFjQJ2IAIIQjZeLRGx8RMj3PpdZSwyA+pbShdW1AdJAUFIEgJmCIPb8IpkDN+IkwBlBy
+ZMu6rt1wOIxk6mjRot0GCK1U4H/srufRNowcZIxk7GQfb9OEqCsI55CSufhiAEMQYNRU2b5uypmb
+VhjbBIYuE6YBhpAdmYij7CO6Izv/Y3n8xBitFjtnjQR5UERMEwVEpOBoBIAEEKVunXnkmCd1VU3r
+spwNppNKwFBtrilAioDIIKZ2yt26W+2Wu9PCFn3ydYGlstQ9p0jAkeooeA50q3BMo0YM8SfkZvlA
+BuStPJiG8KQPy/kyQ9tC5uv7onl0jDgSRKUEJRPkxhECPJH7xzIBZGK4cww+yvPF6iDSGC1atGjX
+gSGLiEKv10u6aZqSOFNV4IcejLWP2vU82uYBUUop2lsAwaJh6g/ig34W1/GbPPWLWSZRe96QFxbe
+lrG9TJgGDEeGBD5zGqJBAoDoswAfVImBEP0VpGgC4GEGdWQi16CyzGpnpnJ/Rpanzv/9TID+bDqd
+VjQeV/Vw6IYLILTWX0ZAFAYEIoc4gHt7e8NuUdSCusfK/3EmY3QEtmaenVJNRS0eMwlrMzpEgjDx
+9P16xkeWWKNBZC5XmdHa7+HBUOX1jRgoV4AQB5Y8/SXXcuFP8soTcnW/EuQ7Go1qE3WIokWLdg0Y
+Qkl20emkye5ungQFfkQN5gr8iBw8UtfzaI8CiNCVAv67kK36vtx5q+RpVjVqAUT8bktJ1CsJ0wu+
+rBKlxz4zY74IGPpbnvsgr/tb7n82XktoBNDkmGdBu6+U2xU7V7nS1eOyVLka8Y91v993l8DXtRYB
+UQsUQeQQuj5JkpR5no8tFDUdJwR+F4fdE0S/ZTJalSTXrrxdDRuR6yk9iLUKrAB3CL1UbjEZGx4S
+yNmISml5vbznWbtkUF7ywV+7T+z4lCflsB5dzIY+BBjBULRo0daCoZ1iP8t6nQ6l6UKBn2hXHSYi
+3NDBR3p/013Poz0GGjKq8Gx1zABs95CZQJm9eCCvN0RKrt5GEvVqwjQjwqMafLg/kPunMhOx+Vff
+J899DBGiCwHtE4cMjnN1VZYAVTXXtavSFD6c+159up0Wu7V/jIBoYXoAIXIoGyhVhUZ+HVIFml/n
+glyeGdu1aPAKonWeWE3Idlkb5BEm36GBrJGsQUEJtEfLeg83gCHlB0E/4USe+GK8oNRfio5JbrP5
+LEN/Uk/qi1qQ0HS6nhwWLVq0CIYaMJTs7HSpk+zLinWk/avJ4IL1aldQUMGLYo07dGSM9p2Gtfkn
+NYTmqHPf81Y8AcYVZfe7tH0k6oYjdJkw3Uf3edBD2D82kMuZ+jsAITb/sOPPzrgzAUHDuizLqfjM
+fDZzrUbolyNAfO8jG+3aY9JOddmjo6Ok0+lkOaW9hCxafLxlUvGr3+UF/5aXyYV/lsfeyUIDMls3
+EKovg6JlMMQMYti5PHIsL/pHnkSI8IO85C957pPMoq9Uu1MzmQ2q4WQ8nF6UpwulzWjRokW7vG7Z
+951O3u3td20n36cEnBKLTuc/iSN9r6AIhFsfZUgNxWzZcxpfNtpJHhtujB+08/ZkBPdDZKgT/E7D
+Xd0OMOQ5QmP5bgBB3+aEaeZvrNVhSoj2pfMszzMfc13LxZ1OK/F94/HUjEb18YYAUIwQ3W7gVi0u
+1O12bWGLLDdJL0lUrPEtsywubH7znYQZhLYfdaFhswcdojXM/jVgSECPjwp9EIT8J6JDHh2bY2f4
+vJxNhjwaTGfTSQRD0aJFu9ZhzsX68nzXJPYHcT4/eY6J+S1UI6GNgy/H9lWxtGIJ5Ct+OMKmJ/ZG
+V5KY5FtIaaFPqhIvpNGgIPGiROttqihrwAt8FgjPAD2n8hs+I/sRAgBfiflcI0REIwAjR6YvvvGC
+66o/KcthfzIBZ7Yyj8iZjVP7FscIYWfIotPubpEV3Z3EmANrSZvmGW3voV2Ef0O/GJmq72SoDijk
+5luRIboRDBEjPPin3P4vQBHrfXfCFZ9Py2p0MbqYhQkR02TRokVbZzaI9XWyItvHWpVoFBvRa/p/
+ZHTzhrULqZUdn9bXdarxCay0XV9Q64JG2jwtEZ3Gk+/Og/9g6+lDqnnnH/Od5BPy1c5pkHa5rqL5
+e5gLYAgk6IF8xxPCRt/wH/Kb/iDlxpovrCX1PJLnoQOoAowom0ep2Nlw+CS+L87tG47PoTlMBAZl
+6Y4AnE6+y4k9sl78CqFn9DrDbgvN835CxOhhYAhRIQFDbP6QYf8oM+i4pvq89FLjs8FgECvKokWL
+du2adXBwgLR+0bFZaFQNoi39R9ac/5HnAYh+k+t3BukyUtHYzCynVZrO4bWsZV4k1l+0hxTF9efJ
+xjKIvCThksqYpOT9ivVtopa6x7dB0DaV1ysn1/j2U+gxBbI0gND/ypP/p7QQEKaZ+w6EaaJZ4qvG
+6nFVVePxuBLf554iEBBTZjeAod5eL7dF2qXc7Ms0hODie3nqZ1/aqM1f5bb5l1xrPv5hYMgIGBLU
+zPRRVqOvruYLV7nRpJrMWhMiWrRo0davWamsWZntylp0YNHxnCDQR+A5/iq3f5bbAEMg4bY7ntMS
+GDJaAo31Bn2iQqsE3Gao+buYOntUCNFIvCxaQXmCNJBPU7V8OSV2307yjw2GGt7QhH1bjVOQpY2v
+GvtLbn+UX/qpQhf62WxOmM6yDBVj7vz8vE2YfnQgHgHRDWAo7aVdC76QJ0//SIgKke6wsMD8JLPv
+HePlILQtiGyrwZD2RaMy6CgADB1fBUPmo3NGwJA5r0f1eNQfzc7lZowKRYsW7TZrVoI2DmwPxF3+
+AK4Qa1pfLz/Jy96ytnhQMNQuyb7swKZhR9+XdQqdEgcKjMjMZA3061FckR4xMuS7H5DhTqgi2wsS
+4knLb29bNOgyGGqiQwDVEBg+k9/1JQgt/i0/B2mzL87x6aws++XFxdSMx/Xp1UjQk820CIhuAYas
+5XdhZwUg9DsiQwLVgxKoLi5e78HncFeBIdeaGCitR6PWY7MAQ38swBApGKpGlYKhM3MWwVC0aNHu
+smbtWy3BRiSbNa0vF+jTIDJ0YFD5elUOZIX8B52ytkzQy5mKxTKhmWYV16RHhRIYl0y7JLBWjR3J
+g0hVpgHENvp22xYRugyINFXmsyGEbgvHAoZAoP4oc018HwkYMqezWTm8GF5MkRoz35kfGwHRbcEQ
+ERRA/635d1Zw9La1uPid1iKESWZZllzZ9XIH6tc6MaArpAqcHgz9GcFQtGjRNrNmUdjAAQjR7+KE
+0Pn8X4hkr+h4vgyGmlQ+1ijDn42SXzXFcWLQW4rQKsH4flCxSn/DEELTZBQ0obrgoxqtBFQXAD+z
+axbVxdvqF9oNWn2JPQFc87H8OogM/43KMplnmFvfZBYNXOm2AgxFQLRs9uDgwCL/riFn7LKahYWg
+L2T+TT469LOfpBoZau+0Lufhm0VmHn42vhXHMUN92itwChDiDxEMRYsW7T5gyAsvZhl4jpc2cNBD
++w+i2uxL7MFxvNzx/GpkKPAajS+FVh00eQ9xZHyC1Bmjd5RVsjWb2AR2oyhCjqhFqkyOMWQQ9kl7
+WZpCHjsS7Fk3FWe0PS04zAof1W7Qikgj0q3fAqiGuDAunwCwUVI/M+Vkaqal2ZLK6QiIwuRCmWqn
+01EyIvLvGnJuLSyyAPzOCEEbfks+MoQc/Kq2HGtacUBQ03xVlExAyeaDJ5XRJ9UZimAoWrRod1u3
+LORA0h5p0Qd4jmED97ssH//2a5bexwZun5Y7njc27y5u0MzaC8Miev2nVrsa+hAUg0/FgQ3BIWKi
+Omo4bjo4hOaYFJq1qso0okQV+4FuiNV5uP09W3FcacpqPANc+5OZZd4QeGffGhK1CbwhZ/jYOfF3
+s2o8nA5nrX5j393SuKgYCwGz3c5uXlhZWoiUjKj5dw05t8BQ0Bgyt60ku64Vh9wmLDTOfHMzc1FN
+IxiKFi3a7deutvAiKmDZV5P9FlL7S2vWiupXY1rpfONVgsEVQlrjgwdD5g9Zn6CFduys61fsJq52
+VcKJi4BoY0DIOOe0tF4sS7SPuD6Tsd907+uFSUASd33/TPM9uta3QZC71JS1FjjnzKWqMqOFQwww
+hADAX74NB32ROXVazmbDoKtXmy2qnn7NgGghuCiLSlZkECjTMlVVcVUyIgQX6Te/y7qv4CJy8SF3
+6rv2XmnF4YY8Hk3LMoKhaNGi3cIa4cUc6xZbWcrIvCevi/b7gufIb68BQ0vKwYhgh03b314ln/4E
+GFL5D6jkV9V4MBiUQQst2gZtx+wke2/2iHagPM0dwZq7MhZvyMsjvEPvOXn8AACJVlM0ngYMLXhB
+MwHf86as8jVKM9epktewgWTDSEAcsiKfMJfkcfF/2qx1zhtqqU5vjb1WQKREROTeEW7GDguLikw6
+5N9/DGWqv4GM+GDBxVu24jiLrTiiRYt2i7ULXEek9zWirVxGfue10RQI/drwHDW1fz0YmgWeB0jU
+4A3pWqXrFCG1AfkPd15X9WhcjRsttLhGbRjcFt2C0jzNrLE7AoYOxZH8S/vNGc1SCNDlH2T89gJn
+tVGiftrI0IIP23SjBzdI5Rh8upUbOQZfWaYFRNqg9Yv8MaqpP8r9E3mbi5lxW8Ubeu2A6IkFF5tW
+HORbcWBSOAFD2opjNBtNYsf6aNGi3WHtWiW8SCq8+AvkQFoVsL2VYCisVWZe9TqvAPrLR7C1rcJx
+TXwOYdjRSdRCeywwtLu7a/NOnlMCrSE+JBafgzYrHtzi+n2rOrCdLnu66NASBYSQWv0m11fkGOR5
++LJa5mAp4Ggi/s4Tqpm/GueOawHXpStHw8lkq3hDrxkQPY7g4k2tONCzBeFnbcXBmBTj4WTY5E9j
+K45o0aLdeu1aKbzoN3FtbTREE9aDoUYcVtYkrXqleTm0Fnnopk3WKajkRzD0OOO5MtJHuin/VcGt
+4fcCTt8gOmSWqwOfMlXWIt2TL5/XNNhVOQaQwOWCarjaR4zMyJEZ+AatZdOgdet4Q68VED2G4GJs
+xREtWrSnXrseJrzI3BKH1TJotFBAquwjuI2azi+rETZtMU32OOMJ/movy3LKMhCl983lSJ8BQV7T
+niBVd75D9/olDT0TSPeIHso3wFxRuRi5vZBjSII+FeYZepEZRIrMBM+Vzk1bYGhr51P6SheUhwgu
+GhNbcUSLFu0Jneey1tADhBcXWkNeKd9rDf0JCRBUvaLQA9xGTedv8U7+OY+nCXIJGVHHeDqG+Bw0
+C9dI3y80j/Sxp2pcjfQ9BRi6Sron+iLf4C/1bcb8KfPlk2NNiQ2NNTPjnPa5Y+dQgu80WtRq0Crz
+6UkatEZAdH8wdFfBxcvIObbiiBYt2qM7z2WtIfYbOcP/voXwojHrtIbAb9S1Snf7SJV9Q9UrCj0C
+tzGuU48wpnO5hKzYtca+kYP8PkSFfiVziRC/WuvuKQDR5bYbX9FuA1xYAeAf2KdXvzrjLip5jStd
+lTnnytmMp0RsrYWOAH+PBq0REK23m9Sn7y64GFtxRIsW7amd55LWkPkN65fXGrqF8OJarSH6w6vl
+00d2fAw9NEiAoOrVxEKPR/FHV+QSjPkXmYZETb+wFveYoxWRvqdOlbXbbpwo6Z4Dz8youOLX0rjT
+qqpGw+GwLcewrinrs5hLLxUQ3U19+m6Ci7EVR7Ro0Z7eeW5ea+iDabSGsFZBHFb10KIEyGP4pGdD
+og7CiuLwoDR9Om+7AaVpbc4qPo/5HGBoPFY5hvZ8edbz5iUConupT9+6rD624ogWLdr3cJ6b1xrS
+ylcUezT8xrhWPc54PhMSdbvtxkjuCYCmLzL3MGc+zttuyFwqfWSoAUMvhmeWvsSJ92jq07EVR7Ro
+0R55DXtCraGTudZQXKsedYO+5STqNoBu84aOSSNCqETkrW+7EQHRioXkJvVpg4qMhfr0dRMwtuKI
+Fi3a04OhqDX0osb0mZCoV/OGzHzOfN72thsREK1YSK5Tn/ZIXCfjGxIwxAhNLiZfe3DbjeqwsPiQ
+M8rqYyuOaNGiPeIaFrWGXow9NxL1Vd4Q6wVCjCcQWJyZcmvbbkRAtHohWak+jRxt2FkdEvMuugaT
+n3RzgUR5fRhh/dcFKXIocCJNdoz+PqEVxx+xFUe0aNEeaw2LWkPPf0yfCYn6drwhZ86rWTUeTodb
+23YjAqLbq0//yNox2OzJotENE68K0R95inSA2Y9xGGjWSSJ/i2qyb8YjZohS+VLV2IojWrRoG1jD
+rgovtnXS+D9Ra+h5jukzIlG/at7QSwFEt1WfRv5dwBDvyp/k8jigz0QenzEZdOitAjhy+oyfK8BG
+lbxUtTswSXzYkH3Ymemf2IojWrRoD13DzErhRdUWUuFFXw0btYae45huPYl6wTUD8f6iId4zyutR
+KPRKeEMvARBdJ7goC4n5j6pP+10VyNO74bdi0UCTuqG8ri+PD2VWTDQSZAiy403GjANI8rstv8B8
+Max6Q58dFpbYiiNatGgPdJ6rhRfpt7Chu0kaxJioNbS9Y7rtJOpWRJE88R5cISVRy+XV8IaeMyC6
+jeCi31UZ+lkWhx9k9HYJv5N0ARAAZM58QzqkwVRLaCi7p6k8VgUohCgRo3Mv+0VmgLyqPPpN3u/E
+OTqNZfXRokV76KZug8KLUWtoW8d0e0nU84iizKlvDMkYo0AIPDNPvIf44ivgDT1XQHQbwcUGDP2k
+YIgEDLFJtOuujwY1XKBPgUUPYCQTQqNENelEIfapM3CIfDhRm9dpXt4NzKQcxrL6aNGiPWQt24jw
+YtQa2v4x3W4SdRNR/OwjQwqicf2F3Osk3j8XQHQ7wUWZeCAfBjDUCxNtplEeEKOJfD8WT44GJ0gA
+EfUZnCKriwvL9OTwn9PuvcxYcCa1tZO6qqb16GI2nU6qGHKOFi3afdayjQoveq0hpPWj1tB39k9b
+TqJuTEvs2fOG+mzoWKYEfOHfMhc/KiXEuG+G6wGX5avgDT03QHQbwUVF4DJsP8rjb/wigip6msjz
+A8E5JwxStOyaNKeuTeoQIjSnGv0hEKxJMI9lQcaCgxwzLp5o7eR2NZ5OKyDl4WTSoOW4sESLFu3u
+YGhDwouNcr5BmoxCP8WoNfTkY2qejxJ1kyqbyQePxEWeL7ou0Gdi/ir+8LRmHggKmkx99PFVzZv0
+uSwgNwkuGg05myPjxRZhoc0Ge7IYNSFB7J5Qfsonzrp+xW7ialclnDgBRIZmMzObTlkmA+N+kiQ8
+nU7d+fl5E26MZfXfb+FZdZJHi/aswNADhBf9Dr9dXq9l0oTUWNQa+k7j+gxI1O31UuYCgzM7knnS
+l3kD3tmZgCGkXPvGuZFcpmVZ1mdnZ68ORKfPaAG5XnCRGSWpRRhAhANPDRCvmefU/w6qm1/k9onM
+in5ZVWPZOZWhQd06R8vRAX834EO3BET8CECJ4lBE25QdmaNkp9jJbGHvI7xI5ioZdiAPfyNNdxhU
+kv1hvAAj+JHfmOtBPZtNW9pocT4/wlr1DEjU7TWx4Q9VcgsRRsyjmUrQGAHZLDBaHnTWIBjwKn3d
+tgKiOwkuyv1deS5n1hTXWB4DeVrzomZOMAz9xpw7NdVsgBzqeDYr14SSI/D5PkBILwcHB1QUha3r
+WobLmULO1LwoiPPc62hCJGE6MzPykbwkSeaRPNnVNI6D7/C5twVg0aLd2fb29my36GaJ4a7NuKU1
+RKo1dIPwYruizLcSairKZMNnfHuFv+SM+Ft82WcTUh5y7sy4qpqNno2jsHnb2dlJut1uniP9GUjU
+FEjUvB0k6tWgaLEyWv1O8J3y/fRiKXO1S8uytJfAeAREWweGrggukgouynUmf1aLbxyL7/wW8ukf
+5HWr+40NBtPZZFKeR2L0NoEhiwWm1+sl3TRNydqUs8zKE1Zuy/8WOUwAIiK5Sbk11uVcACElpnZE
+uvORBaoaj8dNisBtAoBFi3Zfw5xKmVNKqCB1jPzWVx7JGkYmaA2tFV6kFbt71RuCFIj2KTPmMxND
+I+1E1sELOVHG1rladgi0c3CQFkdHcsJEbL9RVCEDJuMqS5JNE6KuRTuohN556oYJYGhrSNSr1jz5
+HuIzyaB6EWDtQH7VgUyTM1lh+6m1o4KK6ZE5qk7NaYwQbSkYkp2UX0BCSapvxUEAQ1oyj5z6mdFd
+EkLH9F9ZIP5klSHn49hvbHvBECo0ik4nTXZ380SQSeIceGAdwtiCfIiFRO4IWvFLO8mIJvIPWdbF
+X2UVaJqn6URA1URAzVSsNOv5XncCYHGIot3XMpvJvK1kjeKezFekVN6zgiFdz1Qv7QbhxcbmhFh5
+LSrLBuw5RH1UmkFaBHUkhpKMbNKlJAEA4ywOwaMAopRSjazIHejciS+in2Vx+k2e+kU369+fRL0O
+ECUy/3JZPWWuIRqJ5ZcH8v3BITqT7yugyORJliRmtyAziBGi72XXqU9j8fiPl7GXiYddlkfeIB26
+AIZQWn/SRIdkDD/IwP8tG/6vNcd+Y9sKhpoKwgytC9J0h33jXSwkO43+CrSkQtWgikRRE/glcRIJ
+So/NmJgHibUXgqcudDJZ68bj8ar02d0BWLRo93GcAXgzARXJvGZCQchP5PmPvyvhlrUYZH+F1hAt
+v1WIEIUKM/LAqAqfIe8PmRFZHdl1ES23EJeN0c3HAkTYjcF3FmRlrWKNBMlYmt99oQ+/2xIS9aro
+UErawkplaRAYmEJ6Rq4PDUSMyXRlI5jXSZ1QRskb84a/aSvP+TxcdTsCok0P1A3q03MwhN2UnOc+
+tOz/dmrmJEMILdJn1VVQPQU+QZqsruuROMeGPB2rLbYsGogKQoMKQmLBKvSDjDkchz9BDSG3nVKY
+J+T7q6iDsASHQKq2KkDpRF6QpyADFkWZurTsjDv1pZDvvQBYtGj3muA+umg1kuBJtZAEAcn2Z02v
+sE+TyTzrXQOGruIsZrxnxqSVaFgLS/mTjjymArPYKFCkwD0WGsKyYGVUsUbAB+2xpjvpRwETGNf3
+8oIj8/1J1Cv9rKx3Vr5/HgANANGOfO9d+VkCkGT9cyzrLeXymkK8cW3fdu1hdYgKbE7TlCeTCV9c
+XDjzQiuu0y0YpJvUp5fA0Dy07CdaA3AgvghdBahOn8pr5OLOXV0PplU1GQ6HlVyaQbztxOQ7/o4N
+by6/y1g82Wc10UA5yTQ1SlpBSO9lbH9CtY3xBFPNv4fWK7T0RREdYlK1VSiQAwyhSkKA9Fi2y8Ms
+S8atkO/SZ1q6GwCLFu0BpxR4IzmcjThOlNP/QB4IYX4fKBhaTqnQTTt8gznq+zPK3GUr580eaZSU
+Kn9exCP/yGPqx4FYAA/thOgKWqzIeJg3oV3UNpCor3x5WjQFxhoHYJTL+omm54V8/0KcZE/86K6l
+ZCazMkkKU+/VOzKnGJmYOu92a9lOVjSmuh7V2HC6lwSM0ofOjHs6cz25Dw8PbYEdeZatV59GBYaS
+DpfAUJMabwajlkGF2NREXotO9mPZJk0r5rKqKu5yV2bsoR2aIZ2Zs9sO3HWVZ/SEgIgf++x+akCE
+aGC3280Sm4CQuG+tQWr0pyClAE0WJSSapuKGdJ5S63AgYYbWKtgRQ1wsJ40UIQ+OnTJnVeI05Htk
+jgQhn/Llz7wLAIsW7SG7cqPpFS5Qei2gaE/m7r5GFozp0u1TKp7/oXPd7PgokJ4XeJ8p+zRaLBJ5
+qnElTmRDBkCBKNGurlWk47oTiPHZFpCo1633PpXbVJlhDjLAHaq1CaB9qvQBw9MELaysRceGWn5v
+maTJlNIU8w36fbNqWpV9038x8y69w0G8rQO9DZBAigyRoSxjlgll94yF/saS+vRv0ObQclQylxsc
+Wn3fBd0r9B/zAKnJ3aeUZjazNRwjdYm7ELq2Ocq0NQS4qvoCj7XEGfW9IdCI1+PaeSVrrUYyYau2
+qYqky59NvqSc08mEx/0+OtE+eNIdYqu6t0dVp0OogEE+fJO/4VqU16rOSK3tWCc7W6KQGvVVNwEQ
+Ia2AnRbCudhdJ8tTiH35MfGI/EkNkmlP5gtO6swZypAHT3LZ3fy4l+SyAZLjeOkzGfPq1+sAWERE
+0R485z2whvNsIgodeQxOtAhgKL0lGArRIZRHa6Abt7E5hAiFFolQpAM8zZjq2qA+KGWN7mk0qBMu
++ZZUlN00lyisnWFOKah7Iw/OiPX+yKdiTU2o4CXVKUKwYZAy9V1Gfduzg13eNXZm+dycv4goUXqb
+A3ebsuQ7AAlU8KAJnqAV25EHBFnbN/IX/zK6W/fq08aok5zv3FdUYDgw23RxYEw+kGE5Yw1VctcS
+71gLWqztoD+ZzVGYJPCLc0+0la9EKxIiShvB987FjTqHVh4sP4AdHpffhd9rUfot78yhGmlTFUmX
+P5u1pDxxJk3rblG4Tpo6gLn7lNE2YISqyqZZJogkTQzuI4b6RFVV8+oM9rtcQgsWL1yG1OjvxlcQ
+onT1LSu3AguMLvy2JYeB9Qhqq7NAry58xJDTcI0Iz05CScWpzBf5lR3XsSs+E+Kev18HwDhqEUXb
+jAcF50fXqBDVScPO/Lb8Er+j9/yV3J8PCqZ6Giml+UYw2pMCC3C5dEyTAIL8WrUAQ7Td31+jRFgX
+0Yz2iJW0D6DO4nOVjiBAm5wHRb4ZrNFKbnssruIYqzM8IY3kNRNzV/23ZwWIVpUlJ5xlybqy5FsB
+CQeun0wgnURWEBXtGKh7euDzc9MIz6BBqzHvoNqKXXsrBNkuXQxoBhVBJkGQQ4ZiJ7D7fwhVSLvy
+NSuNcOp/GjxyPvzHdRNZuuS1lTkSIki4RizIyWo0330posMTUMQhH8rZSEXSpc9mX1JeU5qWgmAq
+eVx3gnwPZosSPNPUuixLbbOzkTHFuG70N1wPiIBh8XkCUlX/Qk48RiPLX6E+jtSoDNtbmvdxUkmF
+sLhwg4iAgGv2KYNEw76sjiXXShsm/G1lsWuzOKkVsttVn+mBN/+4DoBFNBRtM64H836xwVzM6bs5
+zRb/owFEaOMRglAxVfbUsT/WhTOM4TIIeg5Lh684Yy5Yi0o0uoDoI3iVE/lhHgz5iEfTKqYvf/VV
+/GhH/9xyaTtmVnAxO5q8DM2idM2BQsWXJzrnRZFY2XUjx4jdybqy5BuBhPxJYuFoxBlzpg6PVAcB
+ekJg6CM99vO8FYd3ip6p79H35d0UtxaXTMsIWUmL78JCgRDgxIeRm6+JOQyMpgO8aNLaggHkcS4H
+sCTvI7hHHDB54T/dovmdnfwa7BBYHfJGKpKufLbP3YIbgJzuDLcxOWkVkLshxGs8cIWQWEY+TFYI
+GPL8hQ3+huvA3qI6g7U6w+hOxLyXT/0p9P/R1Oi8BPnqDjoAIsKY6G8iv/PWKh5VhfVj2pPHx/JX
+tT9x138m+5LZ/VUALHqYaI/kiMw9nCa1wFBzLoRIZpypz3RMv2t0KPh/+Has+xl5/tPMr5uBj0Y6
+vbARH8ufgbWBlK+ssTySy4V49YtuniXpXkqn/ZcHiPRAAQztdfeKPMt3BMLsq8Kqv6wtS74JSAQ0
+jb9LyfM0uqyOCFU+KnH+Y0ib+eoLnx/3TP31IciGaBgIYeIQWR0inFvIgWI82c6/pQwmA1Qwvhe5
+NesJs0//O1XA9uWJNTA0+UhFEiIJGqHYcEVS67Ple5KXFQAokk+YyrPVKiB3LRBpTgCiNADbwldB
+EI5b+gi/Yd2acbU6gzQliqgNSlVXpUYv89YCEMaPF6DMmiKFWvmbwNjYAalebuLYufk8X/eZSoRc
+C8CiRYvON9pLnEPYUCbGp2ATrTjToAI7s0h9cfCZ8DngaYJOgA36mUAoVKMVxtkU29x6p0L86OUB
+IqTJEBnKkxx8izfkozXQWcDuG8JN4OAueB282K40HI8AJAR0aH67CijTAwnyZaNGKywAspTn+4M6
+KeY3QUq82wyUWd2Hh9uAKIT9djVyQJyr0wPHhDVSdKknC74bQAWtF2j04n/NxAChDLnVmuZ8OgV2
+SZhIgR+wuanafLYCN9Jc7iSAopn8zqoN5Oh26yeF75iG49rxkTctu0zJjws9yYl4pToD40175MFK
+55Z6LA0QznzFjY4lxmJXQ7u+4maRz97MZ0aLFi3aywFFC9/oK81aKVj2lDQOG/QyaGqNPShSn2FD
+hIFfEn0tvYwae0kv6SSdwlotI4Rmxi+hK/M7n5LSsneUJVtakvUJ3pmpIVdVYKbL8QKYCEJhbL3C
+JxyQOqce+coeRIRQsrirpai+HcdlMHQZvDS3VecDxLAA0vD9Sg9k9DXz6IdZNEiUgWfXQsBXP8XH
+SgBKwFWpmOYOVtn5YOSESoOQblrhSht8uIhO3RDNWf5s0lClpslm7KtJmtJad+fJ7ytdEvZq/rnX
+oCBPRvZgiejKweVVINSs/T1Lv3ftrrYp9cxb1RmF8dUZN5Wqcgu0JEHrA2djEiKKgQjIzkfz5mf+
+bStCIhiKFi3a64kSLdb1yynY0A+AF+kzv7ZijQ1iyHKbXF252o1GoxcHiMzh4SHlWQ6nmYvb2hVg
+goocT3g2/GMgOYP7k4bIyCp3xb7rPCPFhCgR1IRrUifVMPM15ZQHtWkAmR1wPHTHv+wQXeudXctP
+cwA7DWhh8oNZhN/kLkWRlnw9KQel5eB56SeEz9Af40LapXn93CGTB0JWf094+8sQoam/m38u34iH
+lj7bV48gIqQRrYpbDUtpQTSmudtf/74UyOf4zqEagtMQMbIN8LwacPLoP+gYOH/Mab5zuPx7Lv1e
+//04KKQujYWvzjAhhRrK3G3405s0mBbjIO/B4AZ5UCPzh5qxWnHytytClj5zG8AQXxfeixZtxVz5
+3rtyivP0xQCjy2PYnmPIkMzQL89oUsz3PGN0B5DHHPNsVJZ1UK9+WYBoZ2cHIQNxmi4ziQXPp+f1
+CaDdwhAU2wsaGkkoI10+rr6vQiBiNdwb1choLo1TpeD2XYh41Po60sgOBadPl8BQra9HjpOolePk
+1jWtKvvjOzigxdTgpYgGtQEUX64moFtPtDt/Nntl2iSEKo1pynWR/52nuqgNOta/s0r+k/XhTkqa
+yFCDrxYHfOmnIsVYh7TUYhxXl1jSchSIrI8KLgGOxbHz38eYRdSLrod2l7/bHIMloeJM2WqB+E6L
+9zPbWhHCZr0EfuSKRKe8bq7M1z8y803KU3wF4qvR3uc8T+M5dv18qwJvFY2Ez+T+V7l8Dten8tjA
++WjRi+kPugSINLSjVeXUquREpIIR5ZmFXjku7OzJn4d0Jb5hTGi86XUNSvF8JWs6g0p1rh68wKlD
+AAoVQRNGqR/6qdBS/xf2PCD9/EoJxUQth+xzl0TLTKZbnAfXq+3wIgZjruuYrslWWsQgTPjli8gN
+8TLOaRPV+JafPU8RIdUIQjsjwkPQU2QoNKeLqBVdv5jRXMFoxWLGlwJlTfSNyzCWcy6Tv821j1g1
+P5F9FEr1UnwEhozX5pCj3aiitsFZ8zOvLEp3qprxv8i/vweJ6QKQNXnulY6TtmDB8fPYN+x0ZjkV
+SqvAarQHO+Xn6AQXzV39pdmY1Mzz9P/TAAjWViFhU7XUmuKZzNPNSCC8AuBdhzUfkSEBQ/Q19Aj9
+R47SF5lwpzIBh2Vdz2ox8xKVqqkvnq8nZ5c1tXi1WUKo1OLzwMtBNKcvJyB4GJbXhCSaxgpajiUL
+PSq9PBjSnCOcaRlAjg08IlQF7cvL91UYj6kT0jkNCboyvloMgAxE6VJ5SUqKfsDOiG889W/3crry
+AgoQzbKvevLQ0t9pgCJf6/Vpyd3jfdLQSBARu71w6AvyKSOkGRP/GN9+YVt9u/0GzjTdkH2/sH7o
+ijxQYETKaWqdCOQXFwVDnqcULqrG25Dwri45fEOgbf0Z69OVyhHDfMkZ1XM+hdZpRYHsFjrAJjrq
+57aGpMET0wrChqfWimRxFIl8kFN+1k6wme5ImZfhfJzIQZjIz5qGCqCaHtkh8aJSFRuPFJsy3fCo
+ArcJafdnME9Z+Z82UCzaIpnWbFffse8537Cul+JbxjLe4v/NsTz8jzzxt9z+xI6OZQE7r6bVuD/q
+l6PR6NkLMq4ERKP+iIusqNGvRCa8OEHzzWgVF7QJtGlq4cvNaYUS2CW/uijfw4mMsFtTNj7zu2Kd
+hHBcu6H8/oC0fBqkapMG7kmoCIPz9QuBfI9AnN1eVUxoUJJ31uR5Rg3AAB9nzku6zRtR4Lp0yPdA
+OvJVZuHYefl/c8+FfT3lyEcsBMgyqgou5EsgPHpi/AVaFMPWYtwKginIbZoGhko2rfrzi84NEtt3
+7KYLdGmVoG8CsNZ+QrSPg9xylmzMBqsANxQZogXYxA4MCrAjOTyToI/l1Y19V3NrDMU2Ig9xyquc
+oC85TrY8WrQAQ6y9GnE+9uW3XMij/fl56Is+HjtlgfNbCzPkFooxFhsebgoztnueskfLSK9nqtCM
+TSbNizoaYLQJkPwcU7kNf9WFLAx03GTt52OZW/8YgCHmjzIPP8sc+CYeYuBKNxUwVJkXJAq6BIjQ
+BLM77lY7dmdaFEU/sVpINpMDApTYFQeUqVK1pl/WzIR22swTqaEKPaNQKaW7HCcPo5+Hd5iICu37
+yAftEvRi2LQiRKZSMBWY7dxo8dAdtHieeu9PKrMf0kcUlLzZ91rzOkjuxu/tk3qWfGk8gOIbNEeR
+++IItDoPAKDbSrXc9UTmNYuv7xPGHgzJO2J38BmhUvb54xNdjIknZrnireEEea0jv8gsax2xoY1F
+1b0oI97XCy4KWETPO/YdnTOz6BNll8JQWxSO5kYKn1XiFdcDBf+kk8gDOt/2IYpE3tMpc5DFCE5Q
+I4gM1XIfTTRbDIracwXVpQDO5+H8O8YGhfQ+zlOamcfvYxbAKC9veEzY8LDnM/JWzx3doGZekwzr
+JykvVn7DzsNV6p89v8qv/aTFOwq85fItrPkf5VlcPmH+iSe7mJlyMjXT0ryAdh3rAJEekPF4XDvn
+AD6MLYoqoWSkDs7JgmJl8bDz6qH1XtZq9gYIwLefICVYl06ADIQaoeconwHnqZVm7BUye6oWrADA
+eaTunf1crZlbas2mIRRumQRCQ+wNgIgatpIzbdFKaPnzLXbD4Flpx5gDowKNiIYQUmaHZl76qLsa
+BUT3xRqtEnsX0jZQ+JbdgSy8TJ/kmb/kebmQ7BT4BKkz+X0TgXt10w+OF0Rp7Sk2V8Mm3807lL57
+XtVDl4cbwKJpwOKC/L0NqZEF4PTR0gYMfUEYWp766pVgzThUaTZaS5sFks8eEN3JKYc0rq9CVJ0q
+on25v+/PzPlBXeW8vj/ZPkRqQ4XPOdomyBP/BOf0WRaRb/I1MY9m2vD4sWRVA1XzSTc8j/MzZB2S
+dYl1jThAmwr5um9YO7zLxtyvr8k9U3/Pll/VKrNveEPYmH3DHFMwZMzfst7/IwvXsXPmvJpV4+F0
+OOv3+y8KDF2JEDUL9nQ6LdF6I0mSMs/t2CK87JA6g+5h6GFmV7s1Fa/2jVwBehYNSquqLmczx2mq
+zUlDQ9HUou0qmXOyXKQOPJB5KXhIvC0DqnY/L97aCeYBgmVuLxBNXzff2+3Gkxe/sE4UKAII+rYS
++8rlMTQIkzYN4LDhENEDvrLxhHdEKDRygXTpZwVCzvwpb/+XLsKoLmAegkPEHty2vY86IEHUi35p
+zoV+afN2cvTQU+gpweIGY9ENLgZJfcxwcABDhFC0+UudnIGD02NfB9hoySwq5vg1Q6L7OWUsEhqJ
+lhuoltUoYkgJtCOil5zXd+UYrQJDGqll75zkXDQfjNE0xjdGVNFX5zrix1sSn3TD8zjzR9cM1jY/
+Kv4LZfy3Air7vrEphH15XtBDdz82z5lfNU/NGl84I2sTAwzp2oR5J4fvi0DuU/Hhw4vRxWw0Gt1H
+D+/ZASLThMDG4zEXRaHhWnS5B5Fcu9yzrC1FbnzT+JWAaKnrPQCAACtOJxOe9Pt8FjzD0dERpWlq
+ZV8/zfIssR2bVuw0RYAyN/0ilwBVVZYKqO7b8f1pzz+m0rml5rfIEtItd3E45laARZ6mlfz+JERC
+LkJUYU+jB6Tq1UXQQqKHoSHWnjWhVQjCpcc+RIrIkJwUzvwjv+XYWdeXcZq42lUJL48Dhkq+t6Wq
+smmWWZOmAqSdxV7crmgI/JBj+4RgcXOYyFfmIX2M73ciyyN2+n8GJ/fReI7WEClhpPK1KtDSxoDk
+s8dEd3HKoVyTfeQIkaR9ed07beui5cRKRC5DlCnTVFxoxxOcWkLrgdGj9kBe4vCBL+QrfDwYYv6v
+vOKDblacO5XfPBK/WzI9fqz8qTY8jzZ3lNtJkJPZ1a4IpGvpuTx3BP5qu8KZ73xoni+/Kqz/TnuW
+kRnJ7zjzUWuSdYn/DtVl3wQZvEje0E2AaB4pOjs7M6Yhed49lHytwN7p6WkDvmoIQha2sG3ghScv
+A6pxC1C9AqM3b97UJMAilV2inMl9cfw4aDthoR7LkdjxJ+A8ovbQuGmzQ7gIzvmLllkiMiRgqDZ8
+UVbVeDAYlHKp170VerF09/ao6nQwnti4QiPA5IWA6Tw3D93IPiVY3OCC0wacF3JQ/I6fddH5S46J
+LDp8KvhxJP5QHKLy7HQl3RSQfBEnxW2dcgDO8n/qG/eaAxkBjWzqPGf0BgQw5V6INAVHRpACybUY
+wAuYBj2ttbyQTQGlJVJr4HGAPH0sb/qP/KIP4qX/ABhy7D7K88eyXexzXU0r2YFgjXyCTd6TbHge
+EWmiQEjG2WEN7cvtCznWcHLokoBqZwDshOjOY/nc+VWNL0ZF+FhOIE3ly/ECifqj3D+RNeliZtyL
+5A3dBhCt8q/8AEB03WtoDfC663u9OAM4LMVsmk7EOfZJCc56fCay5ACwdGTtSYgeGNrnpqFsqAhE
+BIMBLvibLHYnztGpm5mLmuvxuBrPBAxde0JgNM/6fVly+pt0GN8PLG5oNb4COMHPEsDpHH9iV52Q
+cf0J82Q6nc5TkZsEki8iSnQHpxxyT6lVKQY7QIUqqRbanCeBVkQ9TZX4KFIXAGlesKCPU8a+Mikx
+l8qzuZFH2AyBtk1qxRxBKufE8/bMB/keCoYYqdWavnLpLgTVjfvTYRm4HE9mj73heaR5I1OmUpqG
+gMexJRoliCbLOme1HyLmCDUdGG6f9nsJ/CoOMiAkGzZDE6QRjaZj+aucW8d17c5LV46Gk8mL5A3d
+FhA9BOg85P3iqh8W1vPzc57NZtXOjq/6y6CY2ar6M6Hqzzwgb99UBZIPYdQqnsk8Vp6Q7lDdwEzK
+oRvyeDQty3NzflcRLn4EQPR0YHFzC84y4PTyBSeO9fKtmpX9qpqOS2tL2SC4FTvQaHd0yhyKG1JU
+lGmlVqO2TpDvwC541/hKTezmuwEI7YOLJn+5q/0RaQ6KMvLl+r71DTdq/UtA6V4E2lWkVvIVPk3K
++g+kL7BbF/B87Eq6cH0ajaejsm/69VMf+yfY8Dzamiprabm/v18KaJ45pomAo75GdWrZPFlzY9HQ
+mgXu2fKrltd/zD+tCB85MgNUk3Fd9idlOewLGHqpvKG40D6v8UkEDGV7e3tFtyg6CSUd8jvajJEm
+sErRftg4AmaFmkDwF0Il36S2dlIjXHF+PptOJtXpQqJ9G46L7Xa7qSxwcliKXQGL+/IrUD0ELkAA
+i56B8z0XoSZM4WMbc6IsACdAUb9yri8waDiR7dfF9KI0q49xPE9vv44tHSs5byzOH5kfnTxNd+SU
+2WdjZZ4A8LAHQ6h2Zb2950Vi6YDRqkj8p6+C9bt+5Z/4BsQq6xAU2bOrBNo7j9kSqZV9OT1IrYgI
+/Z9c/1fe7IPsAb64yp3Xo3o06o9mZ+Zs2xSCn8M8pcPDQyuWZFmW5nmeatFQjVQZLSKM9m6rRqgm
+tq6dypX39alcz/0w25ryXl7/gxCymchGbTKT9f9sOJwF3tCLjg7FhfZ5mA3OP5GdzcZO4MW5sKgK
+ZFy8aCBKBKtxVVXYFQyHw3oLT4anAYubX3CWAKesN9NzAZwTAZxmewDnS1rT1FHtyzzpyTzJ2vPE
+cC4nkKqcoywfmmjy8n1frSiASCUcoNLPHZrzQqCdRqiMzQNQyjXCwABJ9yPQXia1ssovgFNGH+Qz
+/hBni+tPJThmYzcanWwlGHpuc8Qqd7VY5q7eVDS0dgxXpXJxP6zR28qvWrP+16juxvo/Ho+rQJFw
+r2G+RUD0Sk/g1gnRrgrUSjgQNMVPO6TszPrmoy8eLD7igvMcAOdL31SkSKchUuDJ0wpsul4TjXo+
+XaZkbESFFoAIwAltYhiRJS7mj3tNrFspsq9xqQBEqBYbU9Cn8uXO/LfMls+Co79NnBuKgwKAjmDo
+cYDzg33ic+NXPfP1PwKieAJv9gS+slG9/varAotxwXnxmwpIf+C+tvQImmg5WVMkPgpU+BYPaKLs
+eSEhmoS+eXh8AYjaBFpDdyPQKseMldQKfpPvGxhIrbU7drU7K13Z708m036//+J5HC/IJz4nftVz
+Xf8jIIr2KGPIL+gYbKNkflxwtnOeUEsTLWk00chRQs6lAm+095ngWOWFsDMZWVQjgaO2AEqhXUwo
+0feA6DZxySWOGXlStZJajRmwcxc8mzWk1kmLxxEt+trHXJ/iIEWLFud3XHBe8RxRcIQIUp7nFiXa
+GfSuBCih3xl4ISqIVjGEr5Qsi0bGDVB6EIE2klqjRYsOI1q0aNG2dD2cA6WGF1IWBdJsNhWglCCi
+BFGbBxJoI6k1WrQIiKJFixbtOa6RV4DSQwi0kWMWLVoERNGiRYv2EoHSfdfVyDGLFi0ComjRokV7
+9etqBD7RokWLFi1atGjRokX7vvb/BRgA/SS2pkUj6EMAAAAASUVORK5CYII=" transform="matrix(1 0 0 1 14.4197 114.507)">
+		</image>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#CDCCCF" points="95.2,113.5 95.4,115.5 92.2,115.5 91.9,113.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="95.2,113.5 95.4,115.5 93.7,117 93.4,115.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="96.4,113.2 96.7,115.2 94.9,116.7 94.7,114.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="91.9,113.5 92.2,115.5 89.3,118.1 89,116.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="116.8,115 117.1,117 93.7,117 93.4,115.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="111.5,116.1 111.8,118 89.3,118.1 89,116.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="110.3,116.4 110.6,118.4 88.1,118.4 87.8,116.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="116.8,115 117.1,117 115.7,118.2 115.5,116.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="118,114.7 118.3,116.6 117,117.9 116.7,115.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="125.4,116.2 125.7,118.2 115.7,118.2 115.5,116.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="125.4,116.2 125.7,118.2 89.3,151.5 89,149.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="89,149.5 89.3,151.5 79.5,151.5 79.2,149.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="89.6,149.8 89.9,151.8 80,151.8 79.7,149.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="126.7,115.9 127,117.8 89.9,151.8 89.6,149.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="79.2,149.5 79.5,151.5 62.6,166.8 62.3,164.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="79.7,149.8 80,151.8 63.9,166.5 63.6,164.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="67.8,164.8 68.1,166.8 62.6,166.8 62.3,164.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="40.1,171 40.4,173.1 29.3,173 29,171 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="29,171 29.3,173 26.9,175.2 26.6,173.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E8E7EA" points="41.3,170.7 41.6,172.7 40.7,173.7 40.4,171.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="111.5,116.1 111.8,118 51.7,172.5 51.4,170.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="40.1,171 40.4,173.1 39.4,174.2 39.1,172.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D2D1D5" points="51.4,170.5 51.7,172.5 39.4,174.2 39.1,172.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D3D2D5" points="571.1,105.9 571.3,108 564.7,109 564.5,106.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="67.8,164.8 68.1,166.8 61.9,172.5 61.6,170.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="69.1,164.5 69.4,166.5 63.3,172 63,170 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="38.8,173.2 39.1,175.3 26.9,175.2 26.6,173.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="580,105.9 580.2,107.9 571.3,108 571.1,105.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="38.4,173.6 38.7,175.6 25.6,175.6 25.3,173.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D9D9D9" points="50.3,172.2 50.6,174.2 39.1,175.3 38.8,173.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D0D0D3" points="50,172.5 50.3,174.5 38.7,175.6 38.4,173.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#CFCFD2" points="75.7,169.4 76,171.5 61.9,172.5 61.6,170.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="54.7,172.2 55,174.2 50.6,174.2 50.3,172.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#DBDBDE" points="564.5,106.9 564.7,109 558.3,111.7 558.1,109.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="558.1,109.6 558.3,111.7 528.7,111.8 528.5,109.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="53.4,172.5 53.7,174.6 50.3,174.5 50,172.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#C2C1C4" points="585.9,107.3 586.1,109.3 580.2,107.9 580,105.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="54.7,172.2 55,174.2 52.9,176.2 52.5,174.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="58,174.2 58.3,176.2 52.9,176.2 52.5,174.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="59.6,172.7 59.9,174.7 58.3,176.2 58,174.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="58.5,174.5 58.8,176.6 51.6,176.5 51.2,174.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D2D2D2" points="72,173.4 72.3,175.4 59.9,174.7 59.6,172.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E8" points="60.1,173.1 60.4,175.1 58.8,176.6 58.5,174.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#C9C9CC" points="92.3,170.6 92.6,172.6 76,171.5 75.7,169.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CAC9CD" points="71.6,173.7 71.9,175.8 60.4,175.1 60.1,173.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#A1A0A3" points="588.3,109.6 588.5,111.6 586.1,109.3 585.9,107.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECED1" points="110.8,169.8 111.1,171.8 92.6,172.6 92.3,170.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#D6D6D6" points="89.9,172.8 90.2,174.9 72.3,175.4 72,173.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD0" points="89.5,173.2 89.8,175.2 71.9,175.8 71.6,173.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="588.3,109.6 588.5,111.6 586.2,114.7 586,112.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="589.4,109.5 589.6,111.5 587.1,114.8 586.9,112.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CAC9CC" points="125.8,170.7 126.1,172.7 111.1,171.8 110.8,169.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#D2D2D2" points="106.8,173.7 107.1,175.8 90.2,174.9 89.9,172.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E4E4E4" points="586,112.6 586.2,114.7 580.3,117.2 580.1,115.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CAC9CD" points="106.4,174.1 106.7,176.1 89.8,175.2 89.5,173.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="195.3,163.1 195.6,165.2 185.2,165.2 184.9,163.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#DBDADE" points="586.9,112.7 587.1,114.8 580.8,117.4 580.6,115.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#DCDCDC" points="580.1,115.1 580.3,117.2 570.8,118.9 570.6,116.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D3D6" points="580.6,115.3 580.8,117.4 571.6,119.1 571.4,117 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="517.4,123.7 517.6,125.8 402,126 401.7,124 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="528.5,109.7 528.7,111.8 517.6,125.8 517.4,123.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#D7D7D7" points="124.1,173 124.4,175.1 107.1,175.8 106.8,173.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#D9D8DC" points="145,170.2 145.3,172.3 143.7,172.8 143.4,170.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="143.4,170.7 143.7,172.8 126.1,172.7 125.8,170.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CECDD1" points="123.8,173.3 124.1,175.4 106.7,176.1 106.4,174.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="133.1,173 133.4,175.1 124.4,175.1 124.1,173 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="131.8,173.4 132.1,175.4 124.1,175.4 123.8,173.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="513.5,127.2 513.8,129.3 410,129.4 409.8,127.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="512.3,127.5 512.5,129.6 410.7,129.8 410.5,127.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="570.6,116.8 570.8,118.9 567.3,123.5 567.1,121.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="567.1,121.4 567.3,123.5 562.2,123.5 562,121.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="177.6,170.3 177.9,172.4 145.3,172.3 145,170.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="184.9,163.1 185.2,165.2 177.9,172.4 177.6,170.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="571.4,117 571.6,119.1 568,123.8 567.8,121.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="567.8,121.7 568,123.8 562.9,123.8 562.7,121.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#F0F0F0" points="195.3,163.1 195.6,165.2 188.9,171.8 188.7,169.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="196.6,162.8 196.9,164.8 190.2,171.4 190,169.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="171.8,172.8 172.1,174.8 157.2,174.8 156.9,172.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="170.5,173.1 170.8,175.2 157.7,175.1 157.5,173.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="133.1,173 133.4,175.1 127.4,180.8 127.1,178.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="207,169.8 207.2,171.8 188.9,171.8 188.7,169.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="212.9,163.7 213.2,165.8 207.2,171.8 207,169.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="171.8,172.8 172.1,174.8 170.4,176.5 170.1,174.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#F0F0F0" points="156.9,172.7 157.2,174.8 150.9,180.9 150.6,178.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="150.6,178.8 150.9,180.9 127.4,180.8 127.1,178.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="157.5,173.1 157.7,175.1 151.5,181.3 151.2,179.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="151.2,179.2 151.5,181.3 126.1,181.2 125.8,179.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="203.6,174.6 203.9,176.6 170.4,176.5 170.1,174.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="202.3,174.9 202.6,177 169.1,176.9 168.8,174.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="562,121.4 562.2,123.5 552.7,136 552.5,133.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="552.5,133.9 552.7,136 544.2,136 543.9,133.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="562.7,121.8 562.9,123.8 553.4,136.3 553.2,134.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CDCCCF" points="553.2,134.2 553.4,136.3 544.9,136.3 544.7,134.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="203.6,174.6 203.9,176.6 198.6,182 198.3,179.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="401.7,124 402,126 366.7,166.1 366.5,164 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="366.5,164 366.7,166.1 213.2,165.8 212.9,163.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#F0F0F0" points="243.3,174.7 243.6,176.8 238.4,182.1 238.1,180.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="238.1,180.1 238.4,182.1 198.6,182 198.3,179.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="292.7,174.8 293,176.9 243.6,176.8 243.3,174.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6E9" points="243.9,175 244.2,177.1 239,182.5 238.8,180.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="238.8,180.4 239,182.5 197.3,182.3 197,180.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="409.8,127.4 410,129.4 378.5,165.6 378.3,163.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="410.5,127.7 410.7,129.8 379.8,165.3 379.5,163.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="292.3,175.2 292.6,177.3 244.2,177.1 243.9,175 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="323.7,175.7 324,177.8 293,176.9 292.7,174.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACE" points="323.3,176.1 323.6,178.2 292.6,177.3 292.3,175.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#D3D3D3" points="339.1,176.4 339.4,178.5 324,177.8 323.7,175.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACD" points="337.8,176.7 338.1,178.8 323.6,178.2 323.3,176.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="339.1,176.4 339.4,178.5 336,182.2 335.8,180.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="345.1,180.2 345.4,182.3 336,182.2 335.8,180.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="343.9,180.5 344.1,182.6 334.7,182.6 334.5,180.5 					"/>
+				</g>
+				<g>
+					<path fill="#DEDDE1" d="M378.3,163.5l31.5-36.1l103.7-0.2l-29,36.5L378.3,163.5z M410.5,127.7l-30.9,35.4l104.2,0.2l28.5-35.8
+						L410.5,127.7"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="513.5,127.2 513.8,129.3 484.7,165.9 484.5,163.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="484.5,163.7 484.7,165.9 378.5,165.6 378.3,163.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="345.1,180.2 345.4,182.3 344,183.9 343.8,181.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="543.9,133.9 544.2,136 524.2,162 524,159.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="544.7,134.2 544.9,136.3 525.5,161.6 525.3,159.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="351.4,181.8 351.7,183.9 344,183.9 343.8,181.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="350.1,182.1 350.4,184.2 342.7,184.2 342.5,182.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="531.7,159.9 531.9,162 524.2,162 524,159.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="351.4,181.8 351.7,183.9 350.1,185.7 349.8,183.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="374.4,183.7 374.7,185.9 350.1,185.7 349.8,183.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="382.3,174.5 382.6,176.7 374.7,185.9 374.4,183.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="470.3,174.8 470.6,176.9 382.6,176.7 382.3,174.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="383,174.9 383.2,177 375.3,186.2 375.1,184.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="375.1,184.1 375.3,186.2 348.8,186.1 348.5,184 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="531.7,159.9 531.9,162 526.1,169.6 525.9,167.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="532.9,159.5 533.1,161.6 527.4,169.2 527.2,167.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="469.1,175.2 469.3,177.3 383.2,177 383,174.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="540.5,167.5 540.7,169.6 526.1,169.6 525.9,167.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="541.8,167.1 542,169.2 541.4,170.1 541.1,167.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="540.5,167.5 540.7,169.6 540.1,170.4 539.9,168.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCCCF" points="542.4,168.3 542.6,170.4 540.1,170.4 539.9,168.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="470.3,174.8 470.6,176.9 467.6,180.7 467.4,178.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="489.7,178.6 489.9,180.8 467.6,180.7 467.4,178.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="488.4,179 488.6,181.1 466.3,181 466.1,178.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="489.7,178.6 489.9,180.8 489.4,181.4 489.2,179.3 					"/>
+				</g>
+				<g>
+					<path fill="#E7E7E7" d="M552.5,133.9l-8.6,0l-20,26l7.7,0l-5.8,7.6l14.6,0l-0.6,0.8l2.5,0l-8.3,11.1l-44.9-0.2l0.5-0.6
+						l-22.3-0.1l3-3.7l-88-0.3l-7.9,9.2l-24.6-0.1l1.6-1.9l-7.7,0l1.4-1.6l-9.4,0l3.3-3.8l-15.4-0.6l-31-0.9l-49.4-0.2l-5.2,5.4
+						l-39.9-0.1l5.3-5.4l-33.5-0.1l1.7-1.7l-14.9,0l-6.3,6.1l-23.5-0.1l6-5.7l-9,0l-17.3,0.7l-16.9-0.9L72,173.4l-12.4-0.7l-1.6,1.5
+						l-5.5,0l2.2-2l-4.4,0l-11.5,1.1l-12.2,0L29,171l11.1,0l-1,1.1l12.3-1.7l60.1-54.4L89,116.2l2.9-2.6l3.2,0l-1.7,1.5l23.4-0.1
+						l-1.4,1.2l10,0L89,149.5l-9.8,0l-16.9,15.3l5.5,0l-6.2,5.6l14.1-1l16.5,1.1l18.6-0.8l15,0.9l17.6,0l1.6-0.5l32.6,0.1l7.3-7.2
+						l10.4,0l-6.6,6.6l18.3,0l6-6l153.5,0.3l35.3-40l115.6-0.3l11.1-14l29.6-0.1l6.4-2.7l6.6-1l8.9,0l5.9,1.4l2.5,2.3l-2.3,3.1
+						l-6,2.5l-9.5,1.7l-3.5,4.6l-5.1,0L552.5,133.9z M484.5,163.7l29-36.5l-103.7,0.2l-31.5,36.1L484.5,163.7"/>
+				</g>
+				<g>
+					<polygon fill="#D5D5D5" points="534,179.4 534.3,181.6 489.4,181.4 489.2,179.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#F1F1F1" points="542.4,168.3 542.6,170.4 534.3,181.6 534,179.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCF" points="534.8,179.8 535,182 488.1,181.8 487.9,179.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="543.7,167.9 543.9,170.1 535,182 534.8,179.8 					"/>
+				</g>
+				<g>
+					<path fill="#DEDDE1" d="M553.2,134.2l-8.6,0l-19.4,25.3l7.7,0l-5.8,7.6l14.6,0l-0.6,0.8l2.5,0l-8.9,11.9l-46.9-0.2l0.5-0.7
+						l-22.3-0.1l3-3.7l-86.1-0.3l-7.9,9.2l-26.6-0.1l1.6-1.9l-7.7,0l1.4-1.6l-9.4,0l3.4-3.8l-14.5-0.6l-31-0.9l-48.4-0.2l-5.2,5.4
+						l-41.8-0.2l5.3-5.4l-33.5-0.1l1.7-1.7l-13.1,0l-6.3,6.1l-25.3-0.1l6-5.7l-8,0l-17.4,0.7l-17-0.9l-17.9,0.5l-11.5-0.6l-1.6,1.4
+						l-7.3,0l2.2-2l-3.5,0l-11.5,1.1l-13.2,0l3.2-2.9l12.8,0l-0.9,1l10.3-1.4l59.6-53.9l-22.5,0.1l3.6-3.2l5,0l-1.7,1.5l23.4-0.1
+						l-1.4,1.2l10,0l-37.1,33.9l-9.8,0l-16.1,14.7l5.5,0L63,170l13.1-0.9l16.6,1.1l18.5-0.8l15,1l17.1,0l1.6-0.5l32.1,0.1l7.3-7.2
+						l12.2,0l-6.6,6.6l16.4,0l6-6l153.5,0.3l35.3-40l115.6-0.3l11.1-14l30-0.1l6.2-2.6l7.1-1.1l9.4,0l6.3,1.5l2.6,2.4l-2.4,3.3
+						l-6.3,2.6l-9.2,1.6l-3.6,4.8l-5.1,0L553.2,134.2z M531.7,159.9l-7.7,0l20-26l8.6,0l9.5-12.5l5.1,0l3.5-4.6l9.5-1.7l6-2.5
+						l2.3-3.1l-2.5-2.3l-5.9-1.4l-8.9,0l-6.6,1l-6.4,2.7l-29.6,0.1l-11.1,14L401.7,124l-35.3,40l-153.5-0.3l-6,6l-18.3,0l6.6-6.6
+						l-10.4,0l-7.3,7.2l-32.6-0.1l-1.6,0.5l-17.6,0l-15-0.9l-18.5,0.8l-16.6-1.1l-14.1,1l6.2-5.6l-5.5,0l16.9-15.3l9.8,0l36.4-33.3
+						l-10,0l1.4-1.2l-23.4,0.1l1.7-1.5l-3.2,0l-2.9,2.6l22.5-0.1l-60.1,54.4l-12.3,1.7l1-1.1L29,171l-2.5,2.2l12.2,0l11.5-1.1l4.4,0
+						l-2.2,2l5.5,0l1.6-1.5l12.4,0.7l17.9-0.5l16.9,0.9l17.3-0.7l9,0l-6,5.7l23.5,0.1l6.3-6.1l14.9,0l-1.7,1.7l33.5,0.1l-5.3,5.4
+						l39.9,0.1l5.2-5.4l49.4,0.2l31,0.9l15.4,0.6l-3.3,3.8l9.4,0l-1.4,1.6l7.7,0l-1.6,1.9l24.6,0.1l7.9-9.2l88,0.3l-3,3.7l22.3,0.1
+						l-0.5,0.6l44.9,0.2l8.3-11.1l-2.5,0l0.6-0.8l-14.6,0L531.7,159.9"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_386_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#835065" points="130.9,113.3 131.7,117.9 123.1,117.9 122.3,113.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="122.3,113.3 123.1,117.9 118.1,121.7 117.4,117.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#AE5B67" points="126,117.1 126.8,121.7 118.1,121.7 117.4,117.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#C46674" points="130.9,113.3 131.7,117.9 126.8,121.7 126,117.1 					"/>
+				</g>
+				<g>
+					<path fill="#8E576D" d="M121.8,112.9l10.4,0l-5.8,4.5l-10.4,0L121.8,112.9z M126,117.1l4.9-3.8l-8.6,0l-4.9,3.8L126,117.1"/>
+				</g>
+				<g>
+					<polygon fill="#BD6370" points="130.9,113.3 126,117.1 117.4,117.1 122.3,113.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#825065" points="126.4,117.4 127.2,122 116.8,122 116,117.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="132.2,112.9 133,117.5 127.2,122 126.4,117.4 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_380_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#835065" points="125.2,117.6 126,122.2 117,122.2 116.2,117.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="116.2,117.6 117,122.2 112,126 111.2,121.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#AE5B67" points="120.2,121.4 121,126 112,126 111.2,121.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C46674" points="125.2,117.6 126,122.2 121,126 120.2,121.4 					"/>
+				</g>
+				<g>
+					<path fill="#8E576D" d="M115.7,117.2l10.8,0l-5.9,4.5l-10.8,0L115.7,117.2z M120.2,121.4l5-3.9l-9,0l-5,3.9L120.2,121.4"/>
+				</g>
+				<g>
+					<polygon fill="#BD6370" points="125.2,117.6 120.2,121.4 111.2,121.4 116.2,117.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#825065" points="120.7,121.8 121.4,126.4 110.6,126.4 109.9,121.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="126.5,117.2 127.3,121.8 121.4,126.4 120.7,121.8 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_374_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#835065" points="113.6,128.3 114.4,132.9 105.1,132.9 104.4,128.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A72" points="104.4,128.3 105.1,132.9 98.5,138.2 97.7,133.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B67" points="107,133.6 107.7,138.2 98.5,138.2 97.7,133.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#C56674" points="113.6,128.3 114.4,132.9 107.7,138.2 107,133.6 					"/>
+				</g>
+				<g>
+					<path fill="#8E576E" d="M103.9,127.9l11,0l-7.5,6l-11.1,0L103.9,127.9z M107,133.6l6.6-5.3l-9.3,0l-6.7,5.3L107,133.6"/>
+				</g>
+				<g>
+					<polygon fill="#BE6370" points="113.6,128.3 107,133.6 97.7,133.6 104.4,128.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#835065" points="107.4,133.9 108.2,138.6 97.1,138.6 96.4,133.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A72" points="114.9,127.9 115.7,132.5 108.2,138.6 107.4,133.9 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_368_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#825065" points="106.3,134.1 107.1,138.7 98.1,138.7 97.3,134.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="97.3,134.1 98.1,138.7 91,144 90.2,139.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#AE5B67" points="99.3,139.4 100.1,144 91,144 90.2,139.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#BD6370" points="106.3,134.1 99.3,139.4 90.2,139.4 97.3,134.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#C46674" points="106.3,134.1 107.1,138.7 100.1,144 99.3,139.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#825065" points="99.7,139.7 100.5,144.3 89.7,144.3 88.9,139.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="107.7,133.7 108.5,138.3 100.5,144.3 99.7,139.7 					"/>
+				</g>
+				<g>
+					<path fill="#8E576D" d="M96.8,133.7l10.8,0l-7.9,6l-10.9,0L96.8,133.7z M99.3,139.4l7-5.3l-9.1,0l-7.1,5.3L99.3,139.4"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_362_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#825065" points="98.9,139.6 99.7,144.2 90.3,144.2 89.5,139.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="89.5,139.6 90.3,144.2 82.9,149.9 82,145.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#AE5B67" points="91.5,145.2 92.3,149.9 82.9,149.9 82,145.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#BD6370" points="98.9,139.6 91.5,145.2 82,145.2 89.5,139.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#C46674" points="98.9,139.6 99.7,144.2 92.3,149.9 91.5,145.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#825065" points="91.9,145.6 92.7,150.2 81.5,150.2 80.7,145.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#935A71" points="100.3,139.3 101.1,143.9 92.7,150.2 91.9,145.6 					"/>
+				</g>
+				<g>
+					<path fill="#8E576D" d="M89.1,139.3l11.2,0l-8.4,6.3l-11.2,0L89.1,139.3z M91.5,145.2l7.5-5.6l-9.4,0l-7.5,5.6L91.5,145.2"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_357_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#835065" points="154.6,167.4 155.6,173.6 133.5,173.6 132.6,167.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="132.6,167.4 133.5,173.6 125.9,180.1 124.9,173.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#AF5B68" points="147.1,173.9 148,180.1 125.9,180.1 124.9,173.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#C56775" points="154.6,167.4 155.6,173.6 148,180.1 147.1,173.9 					"/>
+				</g>
+				<g>
+					<path fill="#8E576E" d="M132.1,167.1l23.9,0l-8.3,7.2l-24,0L132.1,167.1z M147.1,173.9l7.5-6.5l-22.1,0l-7.6,6.5L147.1,173.9"
+						/>
+				</g>
+				<g>
+					<polygon fill="#BE6371" points="154.6,167.4 147.1,173.9 124.9,173.9 132.6,167.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#835065" points="147.6,174.3 148.5,180.5 124.6,180.4 123.6,174.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B72" points="155.9,167.1 156.9,173.2 148.5,180.5 147.6,174.3 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_352_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="265.6,157.2 266.6,164.7 243.3,164.7 242.3,157.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="242.3,157.2 243.3,164.7 236.4,171.3 235.4,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="258.8,163.8 259.8,171.4 236.4,171.3 235.4,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="265.6,157.2 258.8,163.8 235.4,163.8 242.3,157.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="265.6,157.2 266.6,164.7 259.8,171.4 258.8,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="259.4,164.2 260.4,171.7 235.1,171.7 234.1,164.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="266.9,156.8 267.9,164.3 260.4,171.7 259.4,164.2 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M241.7,156.8l25.2,0l-7.5,7.3l-25.3,0L241.7,156.8z M258.8,163.8l6.8-6.7l-23.3,0l-6.9,6.6L258.8,163.8
+						"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_346_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="281.5,157.2 282.5,164.7 268.6,164.7 267.6,157.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="267.6,157.2 268.6,164.7 261.7,171.3 260.7,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="274.7,163.8 275.7,171.4 261.7,171.3 260.7,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="281.5,157.2 274.7,163.8 260.7,163.8 267.6,157.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="281.5,157.2 282.5,164.7 275.7,171.4 274.7,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="275.3,164.2 276.3,171.7 260.4,171.7 259.4,164.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="282.8,156.8 283.8,164.3 276.3,171.7 275.3,164.2 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M267,156.8l15.8,0l-7.5,7.3l-15.9,0L267,156.8z M274.7,163.8l6.8-6.7l-14,0l-6.9,6.6L274.7,163.8"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_340_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="296.2,157.2 297.2,164.7 284.6,164.7 283.6,157.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="283.6,157.2 284.6,164.7 277.7,171.4 276.7,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="289.3,163.8 290.3,171.4 277.7,171.4 276.7,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="296.2,157.2 289.3,163.8 276.7,163.8 283.6,157.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="296.2,157.2 297.2,164.7 290.3,171.4 289.3,163.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="289.9,164.2 290.9,171.7 276.5,171.7 275.4,164.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="297.4,156.8 298.4,164.3 290.9,171.7 289.9,164.2 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M283,156.8l14.4,0l-7.5,7.3l-14.5,0L283,156.8z M289.3,163.8l6.8-6.7l-12.6,0l-6.9,6.6L289.3,163.8"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_335_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="224.1,169.2 225.1,176.4 203.3,176.4 202.3,169.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="202.3,169.3 203.3,176.4 198,181.5 197,174.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="218.9,174.4 219.8,181.5 198,181.5 197,174.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="224.1,169.2 225.1,176.4 219.8,181.5 218.9,174.4 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M201.8,168.9l23.6,0l-5.9,5.8l-23.7,0L201.8,168.9z M218.9,174.4l5.3-5.1l-21.8,0l-5.3,5.1L218.9,174.4
+						"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="224.1,169.2 218.9,174.4 197,174.4 202.3,169.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="219.4,174.7 220.4,181.9 196.7,181.8 195.7,174.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="225.4,168.9 226.4,176 220.4,181.9 219.4,174.7 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_328_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="240.7,169.2 241.7,176.5 227,176.5 226,169.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="226,169.2 227,176.5 221.7,181.6 220.7,174.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="235.5,174.3 236.5,181.6 221.7,181.6 220.7,174.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="240.7,169.2 235.5,174.3 220.7,174.3 226,169.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="240.7,169.2 241.7,176.5 236.5,181.6 235.5,174.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="236,174.7 237,181.9 220.5,181.9 219.5,174.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="242,168.9 243,176.1 237,181.9 236,174.7 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M225.5,168.9l16.5,0l-5.9,5.8l-16.6,0L225.5,168.9z M235.5,174.3l5.2-5.1l-14.7,0l-5.3,5.1L235.5,174.3
+						"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_323_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="324,159.4 325,166.9 309,166.9 308,159.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="308,159.4 309,166.9 303.7,172.1 302.6,164.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="318.7,164.5 319.7,172.1 303.7,172.1 302.6,164.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="324,159.4 318.7,164.5 302.6,164.6 308,159.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="324,159.4 325,166.9 319.7,172.1 318.7,164.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="319.3,164.9 320.3,172.4 302.4,172.4 301.3,164.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="325.2,159.1 326.3,166.5 320.3,172.4 319.3,164.9 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M307.4,159.1l17.9,0l-6,5.8l-17.9,0L307.4,159.1z M318.7,164.5l5.3-5.2l-16,0l-5.3,5.1L318.7,164.5"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_318_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="335.8,159.5 336.9,167 327,167 326,159.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="326,159.5 327,167 321.7,172.1 320.7,164.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="330.6,164.6 331.6,172.1 321.7,172.1 320.7,164.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="335.8,159.5 336.9,167 331.6,172.1 330.6,164.6 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M325.4,159.2l11.7,0l-5.9,5.8l-11.8,0L325.4,159.2z M330.6,164.6l5.2-5.1l-9.9,0l-5.3,5.1L330.6,164.6"
+						/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="335.8,159.5 330.6,164.6 320.7,164.6 326,159.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="331.2,165 332.2,172.5 320.5,172.5 319.4,165 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="337.1,159.2 338.1,166.7 332.2,172.5 331.2,165 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_312_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="350.1,159.1 351.1,166.6 338.9,166.6 337.8,159.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="337.8,159.1 338.9,166.6 333.4,171.9 332.4,164.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B05C68" points="344.6,164.4 345.7,171.9 333.4,171.9 332.4,164.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#BF6371" points="350.1,159.1 344.6,164.4 332.4,164.4 337.8,159.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#C66775" points="350.1,159.1 351.1,166.6 345.7,171.9 344.6,164.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="345.2,164.8 346.2,172.3 332.1,172.3 331.1,164.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#945B73" points="351.3,158.8 352.4,166.3 346.2,172.3 345.2,164.8 					"/>
+				</g>
+				<g>
+					<path fill="#8F586E" d="M337.3,158.8l14.1,0l-6.1,6l-14.1,0L337.3,158.8z M344.6,164.4l5.4-5.3l-12.2,0l-5.5,5.3L344.6,164.4"
+						/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_307_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#845166" points="380.4,171.8 381.3,179.8 358.3,179.8 357.4,171.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="357.4,171.8 358.3,179.8 353.5,185.4 352.6,177.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="375.7,177.4 376.6,185.4 353.5,185.4 352.6,177.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="380.4,171.8 381.3,179.8 376.6,185.4 375.7,177.4 					"/>
+				</g>
+				<g>
+					<path fill="#8F586F" d="M356.7,171.5l24.9,0l-5.3,6.3l-25.1,0L356.7,171.5z M375.7,177.4l4.7-5.6l-23.1,0l-4.8,5.6L375.7,177.4
+						"/>
+				</g>
+				<g>
+					<polygon fill="#BF6471" points="380.4,171.8 375.7,177.4 352.6,177.4 357.4,171.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#845166" points="376.4,177.7 377.3,185.8 352.2,185.7 351.3,177.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="381.7,171.4 382.6,179.4 377.3,185.8 376.4,177.7 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_302_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855267" points="541.2,105.9 541.9,114.6 524.6,114.6 523.9,105.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="523.9,105.9 524.6,114.6 521.6,119.2 520.8,110.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="538.1,110.5 538.9,119.3 521.6,119.2 520.8,110.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="541.2,105.9 541.9,114.6 538.9,119.3 538.1,110.5 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M523.1,105.6l19.2,0l-3.5,5.3l-19.3,0L523.1,105.6z M538.1,110.5l3-4.6l-17.3,0l-3.1,4.6L538.1,110.5"
+						/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="541.2,105.9 538.1,110.5 520.8,110.5 523.9,105.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#855267" points="538.9,110.9 539.6,119.6 520.4,119.6 519.6,110.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="542.4,105.6 543.1,114.3 539.6,119.6 538.9,110.9 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_296_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855267" points="537.9,110.7 538.7,119.4 521.4,119.4 520.6,110.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="520.6,110.7 521.4,119.4 519.5,122.2 518.7,113.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="536,113.5 536.8,122.2 519.5,122.2 518.7,113.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="537.9,110.7 536,113.5 518.7,113.5 520.6,110.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="537.9,110.7 538.7,119.4 536.8,122.2 536,113.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#855267" points="536.8,113.9 537.5,122.6 518.3,122.6 517.5,113.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="539.1,110.3 539.9,119 537.5,122.6 536.8,113.9 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M519.9,110.4l19.2,0l-2.3,3.5l-19.3,0L519.9,110.4z M536,113.5l1.9-2.8l-17.3,0l-1.9,2.8L536,113.5"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_291_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855267" points="535.7,113.7 536.4,122.4 519.5,122.4 518.7,113.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="518.7,113.7 519.5,122.4 517.1,126 516.3,117.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="533.3,117.3 534.1,126 517.1,126 516.3,117.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="535.7,113.7 533.3,117.3 516.3,117.3 518.7,113.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="535.7,113.7 536.4,122.4 534.1,126 533.3,117.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#855267" points="534,117.7 534.8,126.4 515.9,126.4 515.1,117.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="536.9,113.4 537.6,122.1 534.8,126.4 534,117.7 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M518,113.4l18.9,0l-2.8,4.3l-19,0L518,113.4z M533.3,117.3l2.4-3.6l-17,0l-2.4,3.6L533.3,117.3"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_286_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="538.4,122.1 539.2,130.8 522.5,130.8 521.7,122.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="521.7,122.1 522.5,130.8 519.7,134.6 518.8,125.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="535.5,125.9 536.4,134.6 519.7,134.6 518.8,125.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="538.4,122.1 539.2,130.8 536.4,134.6 535.5,125.9 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M521,121.8l18.6,0l-3.4,4.5l-18.7,0L521,121.8z M535.5,125.9l2.8-3.8l-16.7,0l-2.9,3.8L535.5,125.9"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="538.4,122.1 535.5,125.9 518.8,125.9 521.7,122.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="536.2,126.2 537.1,135 518.4,135 517.6,126.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="539.6,121.8 540.4,130.5 537.1,135 536.2,126.2 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_280_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="535.2,126.3 536.1,135 519.4,135 518.5,126.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="518.5,126.3 519.4,135 516.3,139.1 515.4,130.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="532.1,130.3 533,139.1 516.3,139.1 515.4,130.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="535.2,126.3 532.1,130.3 515.4,130.4 518.5,126.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="535.2,126.3 536.1,135 533,139.1 532.1,130.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="532.8,130.7 533.7,139.4 515.1,139.4 514.2,130.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="536.4,125.9 537.3,134.6 533.7,139.4 532.8,130.7 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M517.8,125.9l18.6,0l-3.6,4.8l-18.7,0L517.8,125.9z M532.1,130.3l3.1-4.1l-16.7,0l-3.1,4.1L532.1,130.3
+						"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_275_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="531.8,130.8 532.7,139.5 516,139.5 515.1,130.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="515.1,130.8 516,139.5 512.7,143.8 511.8,135.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="528.5,135.1 529.4,143.8 512.7,143.8 511.8,135.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="531.8,130.8 528.5,135.1 511.8,135.1 515.1,130.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="531.8,130.8 532.7,139.5 529.4,143.8 528.5,135.1 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="529.2,135.5 530.1,144.2 511.5,144.2 510.6,135.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="533,130.5 533.9,139.2 530.1,144.2 529.2,135.5 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M514.4,130.5l18.6,0l-3.8,5l-18.7,0L514.4,130.5z M528.5,135.1l3.3-4.3l-16.7,0l-3.3,4.3L528.5,135.1"
+						/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_270_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="523.4,140.7 524.3,149.4 501.7,149.4 500.8,140.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="500.8,140.7 501.7,149.4 495.8,157.1 494.9,148.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="517.7,148.4 518.5,157.1 495.8,157.1 494.9,148.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="523.4,140.7 524.3,149.4 518.5,157.1 517.7,148.4 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M500.1,140.4l24.5,0l-6.3,8.4l-24.7,0L500.1,140.4z M517.7,148.4l5.8-7.7l-22.6,0l-5.9,7.7L517.7,148.4
+						"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="523.4,140.7 517.7,148.4 494.9,148.4 500.8,140.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="518.4,148.7 519.2,157.5 494.6,157.4 493.7,148.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="524.6,140.4 525.5,149 519.2,157.5 518.4,148.7 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_264_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855166" points="517.8,149 518.6,157.7 496.1,157.7 495.2,149 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="495.2,149 496.1,157.7 491.2,164.1 490.3,155.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="513,155.4 513.9,164.1 491.2,164.1 490.3,155.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="517.8,149 513,155.4 490.3,155.4 495.2,149 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="517.8,149 518.6,157.7 513.9,164.1 513,155.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#855166" points="513.7,155.7 514.6,164.4 490,164.4 489.1,155.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955C73" points="519,148.7 519.9,157.4 514.6,164.4 513.7,155.7 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M494.5,148.7l24.5,0l-5.3,7l-24.6,0L494.5,148.7z M513,155.4l4.8-6.4l-22.6,0l-4.9,6.3L513,155.4"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_259_">
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#855267" points="497.5,165.5 498.3,174.2 478.3,174.2 477.6,165.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="477.6,165.5 478.3,174.2 474.4,180.1 473.6,171.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#B15C69" points="493.7,171.4 494.4,180.1 474.4,180.1 473.6,171.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#C06472" points="497.5,165.5 493.7,171.4 473.6,171.4 477.6,165.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#C76876" points="497.5,165.5 498.3,174.2 494.4,180.1 493.7,171.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#855267" points="494.4,171.7 495.2,180.5 473.2,180.4 472.4,171.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#955B73" points="498.7,165.2 499.5,173.9 495.2,180.5 494.4,171.7 					"/>
+				</g>
+				<g>
+					<path fill="#90586F" d="M476.8,165.2l21.9,0l-4.3,6.5l-22,0L476.8,165.2z M493.7,171.4l3.9-5.9l-20,0l-4,5.9L493.7,171.4"/>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g>
+	<g id="XMLID_254_">
+		
+			<image overflow="visible" opacity="0.2" width="235" height="134" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOwAAACHCAYAAAAV4LWNAAAACXBIWXMAAAsSAAALEgHS3X78AAAA
+GXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAKYVJREFUeNrsnQtb4zjy9VWynRsE
+6N7Z7//13ud5e5s7IYml+p9Tkh0nBBqYpjsBeccTcoNZyz/VRadKzpWjHOU4mkPKJSjjXo6/cmgZ
+uHK8dpzLuB8WrFqALcdwfGX3tf/i/O7+ceH7heCHcnzk8ZPnT3flfuqP/ZDqa8EtwH4NUAVMyun5
+uWtPTqRtW5nG6MY6kTAeO51ouQ8+cjAeReXx0S390j2KqPfe1Q8Pen97q1cJUn0tuGWgPjescn5+
+LpPJxI8Aqa9rnDPvKy/BB4kxiqo6nPbY4AtNuX6/5VjnU0R4Kh8BqvrWawhBY1hobNvYNo2uVqt4
+eXnZgfsitHW5tJ8OVjvPzs78aDSSuq49gQWQXtfrSjR4dYJbR32lXqLyTsLd4VWqcv1+29FdS8Gc
+6KLDJbaZMeZ/x9g0wTVNbEQCxwleT7y9vY0DWGUftAXYz2dV/enpqZycnFRN01Swonbixqgc6OW9
+hDuo0ugqAabeeTxItrROYACK3/Xeg3hFXr50Ae3KWrTBK0tYMT/CwPraB1jbtlX8o2o/Y8wCx+Du
+7i4WC/tFYL3APdKcnPjJbAYYbWxrgNrgfmkw+jh9jXuowVnDT6uBqGdI5eix8ZZy9q+C678BNv2Q
+kgL8t02FLsKPiXgezFP2rsVVXgHsNZzklY9eqqqS+XxuLvTA0j4BtwD7iVzgedP4ajyuasCI6Ro+
+lxvhBhjD4x0DyTHuoxE+PHL2uta4k2o6w3ZbSQq38h1SoH3naOAaao5ENV1JIXyhhxUnLvMSGC8r
+lUd8DGY3IkgRhWscx+MxXWMpFvYTwwp3ytMFhsuLGLWGRQ0EcgR3dwIUp/jMFLBOcaNM8IUJgVWC
+C7BxW3jcL5521nIkaia2APtO42q+SnpBk1Wlk6yAVQgrrKoDpG6B2XHBNFTE20z94TlcZo2IWiIm
+X725uXEF2E8G6z84a8A6BqwY8DrS/RVYU5UxbpspTOcMr58gejoBhjN8CY8AVhK0efzhHjuzsm6b
+1QLtG5xg2XqFeXdOfS7gIWAs1nhc4b1HvPmAMWkYjjjLHlehctpijNoYVu2UqeTpNAJY2fd3CrBH
+Cuv379/9vK595VwVva9xZ4zw88hLnOITsKjuBON8inl+jo8jOHKneI7X3EyTpSXUXMWpYIUrc+b2
+CCzK8Tpg8xP7RxizMv0kjm6wxat4A7Dqg+Ok6myVBxY1tpgrYXX9MvpY1b7xnonl9frZP1iAPcLk
+0rdv3zxjVrq07WpVMzb1iFGFri+AxHmKoGgOIM/wLTvx3pyv43YitLCwOk43j6s1JzT3QFuO13Gr
+feivFrP2sMKSrvC4RDhCWCtnyXhYXLWkE93jWjlh0j+umnTtF4sC7GeB9fz8nMs2XOarJIQGUzVc
+Wz/24me4S07gjJ0apE7PmDjGF89dOvkcFteAnmKOZwLKgMWN0y3mSKH1PWbWFm/sNFidGyaYaFkz
+gQJrq49wljFmUqla7sDntZ9XHQXYI0ou0aqenJx4xqsGK+NQ7ycImAjgabKicoYbgYBe4PzmNANL
+iOEmg8iZc10Mqw1vHOdyDFus67tzTfiHK7DZsmqLn82y5iEM2ZPhcpul9zSnppKswhJVKqtu5acA
+e/SwdplgD8eJSQsu18QE3gwQnmSLekZQ8YVv8Ly+8We150JYGcfSHWbGOLvDwvH36dQu4SRarvuv
+XJ0t+aAkqwraAKpIB6uz+NVETvYhXGDNMPfKxZYZZFzwQPXTum2jUILGSLYAe5ywDjPBJnbw3mDV
+BN7M0QWmZRU5z4B+ww3wDZB+w2+AldVzl+LXk+wOT5y50Tb2VQerbtzh4ha/YE41zWyDp72+qdWU
+bXcpdrXPxQxtlyF+xNWle/xoyzsiS8a44iK+q6GtXPTrVuvFQnd+fwH2WJJLJoZw4yp6V7cSRxRB
+SIwTTwDhBqv4OaC9wLBe4JvfaF1hI7/BTe7i13lKQgFWtSUdwtpkWDOwMlzPKbw+PzC6zW62rCaM
+0ChpqttA6tIyDs57nHf4BbcA9A7fvMf5gPh1Aau7hHVdh/SdqLCyD7e3WizskcF6cXHh5/N55aqq
+aldaUwxRSTXGJD7FuHI99RQ3yJkwRhX5ZvHq5hzAKrTAOW61ZEeTxz27wluxa4H15Vh1F1YGo9GZ
+sBNurdM1LuAKkyUsKYAkpE5vwPE17C1OPDp3g89RynSPc4HXly4yeg2trCS0q1G8fKG8rgB7+Mkl
+jtFIKj/xXqZRBbB6Ws2znFAyF7gDNbnBlmRKltUNkkziXoK1APuK5JKYvqRLGSmLnXJG2OLWR7xz
+D35v8ZxgXuGCXuJbLGEHh8LnhPYWv+ae7jHgXsJLWlc+xbHLu+Wz7nAB9oCTSyKWvW0cNcDeTXBj
+THEDMMs7N1DFnUtnUeEC0yXWfhlHUsya1mU7KWIjW0mmYlnfAGqv7c2wUkYYmGCSlDzieuoD3rwD
+rADVsS79cgCrAZsBvkGgewf/+SFaHBtXwYV1bGN7t76LNzTAxcIeeXLJlEt6igFnpjfDSjeYJ7PB
+LNTRC7O65gYrE0xTgz1JELkEVOF38Hf7nUmiHC+PzU5yyeLVFmOzHsSpjEkRoyZYM6iXGdSfhNcg
+VrlxQ1hVlyGEFc7AsrpcpVMK2A8d1l2ZYZtkhpZcEsvu+pO0ZCPnmN9pRdMaa166MYjxvpj8kJZV
+CHkHa927wQnWYlXfZmGfwIrrSFBNbshYNMWqjmr9BKsTWtefKposq7ITDGD1gs9FWmJaZMK6jhGW
+dRvWYmEPObm0T2ZYZZmhpPhzDtTOXEoiXUgPqtgaK18XZ/LDYbw6hLXacYMLrG+HNeSzg5WCCML6
+YPEoYLXYtLOqAkjF5bgVllUQz6rciSpgjYR1hRDHYL2/vw+3KSv8S1gLsH8Z1l/KDCneN0GEiR8u
+skXNLrDbXrYZJpdcn1zqlm5KvPouWLN6aSA1zC7wwnVLNQnWqwRmB6le9rAqLC/cZe/0QaI+xkpW
+CHfWbOxEWK+vr3/pBhdgDyC59GqZIcG0NdYMqw4ywZ0gYpNcGg9c4GonuVRAfX2SqRNDbGBVXfWw
+itwny6o3zPwaoNK7wohXzdJeM8EE5O+9hgcRwFpXS8DaKiwrXeC3wlqA/UuwvlVm6LbP801yifGt
+MrnUZYJr2b9sU2B9M6xuD6ysuDGrequwnBirq4E1/YlY1ZZuIuNV0RsPWBWwIpZdSlUtI2FFDHxz
+cxOvrq7ia1zgAuxfhPWtMsNkUQeiCOlhPe0t6yYTXFsm2Flta8kE/3tY23xavIrr/JBd4NtsPa+6
+9VUAmaHVK2XySdwt3N97jOdD9Ph+Va8wzj2sl5eX74K1APsHYf1lJniPzNANZIbZ2lpySXO8KnuT
+SyUT/M7kUqdaCtYpIsWrpgFGiHIvlBQ6uXVb8SpAVfdT6AKbmokuMkUTTEbFB+ogrNFaVTHBFAjr
+z58/3w1rAfYPJZdelQl+VmaYxRDSW9aZ7E8ulUzw+2FNlpV9lWBVe1hN2OAeRJU6YFu20U4Q4WBd
+aWHVMsLXYrC6O03LPAtrshbjWkJodb0OtyEEwKr/BtYC7B+A9dWZYE0u8DMyw7PsAu/Wsu5LLhVY
+3wOrS3Ws4rYEEQ9JEOE26iWlZe3US3CBEcdqFkQgxKF+eAFruvSAtY2xXT48hPbuLv545bJNAfYv
+JpfelAnekhlKrmPdmwl+SWZYQH0vrC8IIjTFrBuZ4UAQoXCT2UqYa7IaI93nFYBdrVXD7f19yI3B
+fwusBdgPhPV1mWAASeWSbLvAbtPWpcgMPxbWNwsinNsWROA9lsuZIILZ5LgRRMTfDWsB9gNgfVsm
+GJZUzA3+7rqscM4EF5nhR8L6QYKIqlq7LIhggsm9cY21APsXkkv/puDcDTLBrsgMfzeozh2wIKIA
++4dh/XcF508zwa7IDD8I1sMURBRg/15y6b0F52/JBBdQ3w/rQQoiCrB/OLn07wrOSyb4A5NLRyGI
+KMD+zeRSKTg/FFiPRhBRgP1AWEvB+RHBeiSCiALsByWXSsH5kcF6JIKIAuwHwFoKzo8G1qMTRBRg
+f3NyqRScHwOsxyuIKMD+RlhLwflBg+rcJxBEFGB/A6yl4PyYYD1uQUQB9jckl5LMsBScHwmsRy2I
+KMD+C1gpM7RMMEEtBeeHmlz6VIKIAuw7QHUpEyzUBFO5VArODxbWTyeIKMC+DVTWt/nJfC46m6Vl
+GyaXvKdVLAXnhwjrJxNEFGBfaVH/IVVwf/1o5Efe+xWviRhcTC5NnFRTQFkKzg8N1k8miCjA/gLU
+7+67TOdTqcZLmVaVXzcNPKJYw29tMLAjF8IkxauepXHzLCcsBed/F9ZPK4gowD6FNbu+330CtQKo
+4tuRr0KMFddDY13TGiJeFbjBOnVp53JW25zlyppScP5XYP38gogC7B6ryszv6eg0gxoBaoCrKnUg
+qMqdyU0QMRanM0nWcp6sp1opnHbAloLzPwGqc19IEFGAHa6pwsKNTk+9zGZeG30CKlxcZnHHeAR0
+MkuusMzzLuYXTCrlipvdHc5LwfmHw/qsIOLe1lDV1lGvxKypHK0g4qsD24PCZZrTuq4amcD/oQ4C
+rm/TNLgNRgBxbCdhFZ1iQKcGIcUOapbTkkmS4tSL3DFiIzNMsJoLXDLBfwjWjSDiBhPsdXJ3M6i9
+G/xEELGIHt89YEHEVwa2B2U+n/sZl2kArLYwpy7CAsaRqI7NKtKistjcUd/rZrgBCOFJhnWe4cyQ
+KkUSudKmZIL/mmXtNk9OsNo+rGmdVbvkEpNOeI/7sUZY1rjQ6B/F12tf+YMVRHxVYLc1wICV1TVR
+EJ+OkkWFFZwAWK6rTmE5Z2yQ5ghqhhXjd4rPnKq5vDqXFMfOt62qTEom+COTTH1GuMWPTDAtU8zq
+UsyqJoogrIhVAapw+cbiVksuYcK9U6dwmdUEEbU6WNaqxXNunnyQgoivBuyzrUaDRGqAR97FiXr2
+WfIzuElMKHWC/NPNKXCHtX+O+PYka4FPAC7d32FZXJEZfgyonSiiywivcDUfMdlS5AD3ttcGX2eL
+Svf3CpMwLSst7y1Cm4cAWAWWtYl+XUW3DmsXrhfX8cePH0cL62cB9sVWo75vNZoyv3R348BqZvXS
+aQb1xKC1MjhYUlFCyu9Nzar2SzZFZvjB4DIz3GZgl1kYsYA1vbfqG5VuzTU9UopIV1kpS3SLysVH
+ibJ0oVpLU7XtKsbr/3cVf7jjhvUzAPuGVqMCi6kpLpU+NjWpYVpHlS5+NUs6gHTCpJTbWrKRypVM
+8EfErgML6zYWNgsklECmOJbg4lEf4A4vCDPi3McouoSbvAK0a43aqkQY1nW8W93FS67yHDmsxw7s
+G1uNSoJUehkhZYYp45uywicbUN0wRu3i1MZt1lZLJviPJJwUVlbWALCDNp3C50xEmdppnQsAzI2O
+3kdWRLbgFS/rerXWy8tL/SwXqj5mWF/balRoUUU7ZVJuhibnMoBVuvXUDajNBlLZjVVLJvij41hF
+DCuyAVekh5KvYTKGQd1YS8ULwqwffojyeYekPlZY39pqtIPVUa0k2brC8mpad53qpsC8weg3uQCg
+g7RTLJV49U9BK9JZWwwfULSXpbvmlWgKS1KLHa3hClf4CF7XyodQNYH81rKMywLs304uvafVKCZj
+kxZm1VIvfqAMkZJESyh1oMqTGHVfBrjA+ocmZ6Dnc96AcDYAODXBM2WaiSkofIFnpSul+4zxq+qq
+CurCKIzkArfAlSWTj/+ojg1WZoLZbhRHzeoaQDaunJ+I9zNr2dKJHUS+CYtynPsPT/6cztzIuy8y
+l41o34rV++Ua/0xiqbjBf8IlpuBfzfUNktdkASPcZHaXkGDv5eSUWPWOxbEWuMIlDsG7NjiYWjhg
+o2qkN8sb/QwTbX1ssMKyWvdCuD0NxsNajYqvpnCJTuFEUehwrpQTai4u3241erarAVZmkzcJJe+e
+X1MtkP658U69rsQa1XW5BHpBa0mJJjthea0W1iZcFSqhqGSrRWOlkcUdkdpxiVVMQsXtBFcB9iMH
+sXODrdUoW7cErrHKVL2tsdpWjhsXWJ5vNWrZYN2SFbrtypqSUPqL7u9gDLILbOPDcaIVXWdvqMsa
+j91mbbxWBq1s7aOYxpl8ymcI4dOMY30sgzgajeAD11VoAwYljpQ1q1VFUcOpwah67jpQU4H5t2xV
+u02nkjDCtMO7rUa3yuCKRf0746wDWP1gEq07YCUvs9ErgvfUOCuJ1Brf8njNe6aJO59a9VNeqPrA
+B9EeKeLHzOnX7brG9Dky4AxWSgzdWV6mYa3qd4M1t3DRwT42mtzgZ1qNFlnhgcAqz0Dbn2qabcsh
+53Hi4g7pFGaT2ZSNCzxc5VGW5VR4rKrqKGpdP4WFhStswghee8WsylkW7HKdlb2Bh5Y1JZhEv2sq
+Mu+beCctcGk1emQZKFrLocfTJ6REuzYxffeJtamblK/Z+m3AhB4Ja93WGhdxqHAqMexHusJN0/g6
+1FxjaxxrblyYaFqKYZLpzHVrq5YNJqyWCeba65mkBNOgL3DRAB+R2d2VKbJyZ8WkE8Z/KSnZlE95
+TP2IlbJEnL716kPDlhLrVu+v7z/NdfGHPGa9KxzXzPwhZoljZZMzVtGom2sGtusNnFu4nOcdz4ft
+RscW91gW8dmlmnL8NWO6ZUF7UDUt03TldbmHk95Lqom9y10SWQxwj/tigfvhEV9cRbY+jS548WHd
+rONPq20vMeyHWteLiwuhmN/+G8XVXAPHAMC6soWLlcbNtesE0e8OZ6omi1klx6wZ1lJgfhywxo01
+5RJOqtTR1BXRqnTYn8nZIo2yvO5aYu4xnD4DYOMquNCq1xaTfVwul+oOvBPiMQPbwWrrrZLkgWkN
+LkbrZIjXUo1qX3EjvZi/0wa77Q6GjZQC80OHdbvDRNfF36pw3B1C0dsEKbsistma1cGyYP0abvCt
+8DPWRDwu8FuWgHi91jW7Icbb29tPAeqhAftEHMH1NB9jLd43SXom0+ziJjWT5sqbrs+SPNkoeVhk
+XpJLhw9r67b2x+m33Li1AvXUGJyQ/tTUxpRdEmllbxQusWhYeNGlk3pdtVW7XCzj7d3t0XRDPKYY
+9jlYGx/CWGOcanQzdR4w+nneh/V8cPbqJR10hNCSCT5kWNPJzaxyrDqAdQEg77v9cQawEtL/qXXx
+177XsAa4yjG1L5WqWkkjJklc360Pvin4MVrYvQXoBisXyOvaNk3u92Gl+yu2jNN1MuzXWDHA3Fw5
+Z4MlbZS8iVkLrIcG64ubWbnbbVhtX5z/5QbhPwewwh2OD96zMfigfWm4YaIpfjZY/zawzxagww1O
+XQ3Zf0kj4lI9k7SHTUowqdW0ppjVWYJp1u1qvuUGF1gPF9bnN7O6ZS/hDlaxjayUbvD/3KCL/7Ow
+HnFHxEMG9kkBunU3fLLDubVuOUtF58I61l5yKNv9gaduWxfsd9z9AuuhwfryZlZXeYvIS91Y1i8P
+698CNsH6zz9yUdcerixBrQNgtZpWxKybHc7dXKzSJssON8KIbsc49gie5d5Lu3LDssZ6eLC+aTMr
+xqsJXAP2mr2IEfXefVVY/wawm24R87lnd8OwXNYaIytv6AZPpcsE2w7nbN5NUQTL5FjbKnlvGwLL
+hmqSG3q73TrWAupBwfq+zayki1e7zawAqwes8kVh/dPA9rAywcR4tW1bK52qpKKCaaapc+E87XDO
+HkxykbZ2zFU4vUBCz1IXRItdh2L+khE+PMv62zazkm4zqy8K658EdhfW2tZY23akCneW3SI8+zBZ
+vLpvh/Nv2zucy0mC1e24wkwyaXGFDwrWX29mJZJ2S89x6rObWeHnR1fX3NP1S8L6p4A1eLoC9B7W
+ELgRFXc4nwEzahDZ2fBccqkc49XsCncF6Pt2OB+74VYZTn0B9cBhHW5m5frNrNIO6dJB+2Qzq4fo
+Ee9W9cp7v9Yj3x/nUIHdFUT0sFIQEaNMFJYV8QjXUbuqG8sGO6trle/DAvRndjjfzQoXV/gwYU2N
+wAGrOHbplxu3u/myMsEkdImv8TPeNzki4I4PUePSi1/5um4Djq8K60cC24PDhmncPsNad1hrFzeK
+Uk20cicGoWwK0OkCp5g1L9+4bXGEKwXohwyqex5WGUgNE6z44CYDTGGECje3uhaD1cT8dJltM6sq
+xrVv21bX6/a2beMxb2Z1iMA+US/x7yBe5RrrKFYVG5/NJO1lk8rjNp0ivjNm3WlHWgrQjw/WNp9D
+WE29lCyrXoqpl+RnBy4+c6Vpc+Y7eF7c+GoRIywrYG1jbJf396G9u4s/PqHc8G8C+0S9ZB0OvR+x
+d3BWI1FqOLdT/IXbWFSLWXNN64VuhBGlAP34YB2K+HtdcIY1WVTXnUpxBCyu3GBCZ/ncA2JUus8r
+ALtaq4ZbwHoHWN0Xh/V3A/uiesmxw6HqjLvHiamXhLDm1i76XW29leusemH74ORuES7DWnY4P9h4
+1ZmIX8T6BMu2iP9hR8T/sxPxu07Er8pYlss63PeVJXKPTFBFEW6+3LJErsD6+4F9tXqJMatElwQR
+SWr4XYeCCEVMm3oMz1KHww7WUoB+gLC+UcQ/hDXVtNqerk7vvCot8WOsZKVVtXYhsJ7VEkzuk5XI
+/W1gf6VemvXbZ5h6ibAqYJUusdRJDS9MECGdIGITs5YC9AOG9U0ifpMbbon48RtuAeqD9/Ex1tVS
+KYiAZb29vY3X19cF1t8M7DvUS4xR5VvvDvfqpbSxMsvkcqy7s8ZakksHCesHifivrq6+5LLNRwL7
+XvXS924LDXwurbGmDhInSci/lQ0umeDDhPVDRfyXl5cF1heg+22wWocIwKpUL1XWAcK6Q0juaJiU
+Sy6rl0wrnLfP0K5EbjLYkGrfxsnl+Kuwvk7Eny3oRhTh9ImIn7B+dV3wnwL2F7D6GRA7zbvD5dg0
+x6vqvu/dPmPT2mWwibKmDZEKrIdiWZ/RBT8j4ndDEb/biPhDEfH/SZf4tbB22l/rwj9UL/XbZ7it
+ZZtd9VKVGr8XWA8b1m0RP7saShHxHwywb4H1wvUZYPnPUL3k9qmXkqiiFJ8fE6z7RfxdzPqciH8R
+Pb6bRfwx64IHMWs5fhOwPUB1XduWj13FzT5Y++QSYFWX9rrp1EuyT71UYD0mWBfPiPizLpjxqlxZ
+D2G1eJbxKixrXMCiLl1VGawU8TMTfH19rc+EaQXgdwK7JTcccwex1YqQMRs8ZoLJed22rMpNqQSg
+6n86WIt66RPBui3iR5yahRAqcIMHRecqd6y2Iaz4HtdYV9wlvV6t4vLmRq9vbp7Lp+ie5+V4BRjd
++yaKoDZ4JNI470eVyMSLPxHvT23LjLTG+h3xKiFlcskepVcvSVEvHQ+sw6Wb3g3GGN4/hdUNtcF8
+jRbXuvE7Baze3Oelj7IOUdrWt2EKgsN6rY91bVtB1re185dX+OJP/bEf0iKeeIuF3d7yUZqackPn
+puo8i8m7xt6pUZopmDZu8ADWk6JeOhpYN3vcDBJMFEVgvLjOep0tK3sGWyuX3I/p2gldZX+PSZzb
+bJhFxWdjwBs+BhmHtW+rStajkSK4gtHFLTAV2+Ns6v9x/xWx1+qHB72/vaXQWJ/5by3APucKc/fz
+kY68Rq210ca7aJJD5bJMv+WjfFPdlMc9A2tRLx0urN0Rt6xrJzeUbkMqi0uv8z43lxjvKxNCpGUd
+7iy3wGsrZxlgH12M5qGJj7WXNlaIk2KMyu2XWzyuBUFRJSqnlavgrM1brwhvNcIMnzRNHDcNIrAV
+E1O64y6X8rp9x4W7kHpdS6hDZfFmhDsrVkg+SwXo2gPrTL2UYXXSifiHsBb10mFDGwePrcHKRJHT
+BQvKTR/srAfTdd5F7tZOYQbYxBMrLtOwVw8Oz5AnCj7tPZCEH1zX3B5dE8GiNmtze+bIm0Ft6478
+7xibJowA7EQkrEYj+NItN7aKXx3a+hexq8zmM5lU3se4RLBRw5WtRy7Cf/EmeOiK0M9tE+VuN7kk
+msgd+V+EtYB6mMmmfstHl8URVqfK2tZuT9YE8AOAfoRrDLC5Rw6xFB9wkwBDOGIcc/xEjRQ+oKaH
+SZCJ2v7q6q1nnvKrgFUiXgi+9gFuMWxta1plwc8IycIJrXIqYv+ybvGvXGK3Gq9kOpl60Qqf9QBW
+x7mn0lQNSiGY8yxDPJOuX/AgG+z2d4gosB4WqG4PsCvuem47nKfNlBfpUR7BzhK2k++1tIq0o0Cz
+UarTYDPxmg1wziZKx+ngz2qCVvlRGGL8XRWEuvi7tVsDXUwWFWJgv/LwoCvEvfXpqc0eLtXHfsl4
+tv6VOzwKI49RwaRHtwYzp2hj3Q6t6beJ9U/YI9i21RDraMjXpu7l3ksF1uOwsDil0wxzg2XGs2vA
+1+YaWGdZfmb91ZRpHG9NTi9cYszmPG3caWLT/wZ/zbCOeC2m4nfbhHkVxS0dz+gxMbBjCf9V2X+Q
+zOdujl+a3eMv5xq/COzJ/ER8g+segscU51N7FhkBWg7MJG/vODNIRaeu0wQrYTX1Uuq/9HQXuXIc
+Jqy7mWKCFGkxwQisHw2lMZL6dGGcYSQJaJ0/Sy/XolaX9eB0kfmz6hauG7MrVk8L19eyybCocQnL
+C1CFS0I1eOZ9h2C4Un4d96NeXFzYctDV1ZV8NWhfdInbWSuTyUR8dD7tLCe17buatsbo+gJPMqQ5
+VhWA6rZ7L5Wlm4M/xGJMM3l0VHUrt5NGzKcg1KWwyBnANKsc75hcXOsNXeE3YILmvSUVE09Kd1my
+Z6Xd+BNh2mKFZYVbba63W+K3WLyc7iFO9Onz4FZr/AX+oQhYz87O7LcA2l398ZfbqqN3WUMIHBLM
+c3WlyfWBtbQ4hYM04gybrCkHDZbX8b0nG1KVXeSOleFUgeHTmNKrYigkbbJnWttavJr7rJZFShMz
+75E6N8yruntBU/XVlnpJyB/iVnCYOyy6Be4pJrduDXj4w66Lc3EHMlqWGM375lrtHO4x7tEvlT1+
+1sLC7ZCmaZhO97XUnCFhWS0TDzApS6Ro3yxtsqgEWTKsyQWuBrCWuPVIIJXNJAvIbGNsilzG1rOJ
+CzDJFBNedphoMeZcmOm+Y17Y0MPS5A6bpZTNNipmyfE1uto5G62Polaqd8e/yXsop6m4RMSPGrS0
+5XWABw1guWTE7DGXKtaA9scXgPbZZZ3ZbCYTP5GIyD+5wwYrtb9MOo2SK6SdxLBx27AWXfDxxK75
+Bx1a1gyfYwhEVVsUZ1j6PEmvklWUkINRGVjTenASVLrFVtus2/dClLzeK66vrb1PiSvz5uhFE1W1
+dV1yS+KpjAKwzCdXzIPiv7A5PU2/cdvSfgkL2wO2Wq1kOp1aZQ4uVo2r1fgUvxDSUY5jE7jar7G+
+lFzSAu9hwrozuXbZfFrXkW4+57M3xRambLoWBkGu5CRTsrDdI2Na0aprRNBFw7rpYBHMxd6oqdKq
+gkoOqbsCBA+4LXylOyzqa8stVzHYf1XbNK46P1fu5zLosvgprWz9gjvsV27lEehXXunmmIuTYdWc
+cMpZYIs3bDbdhbUUJB8HtFvw0o3N1q/Jd71P2m+Ou8WwIYE0hF3pQluSqbe24rquIfm+0Jze6u4L
+g77F91b5b/n8G3P7VLPs0dDlqm3GXWms82oQM80SfRzLOE4mEwWw8tVcYnOHYVkRXbSV1DVmSc9M
+X27fIp14Pz9XywZS2z1gdbg0MEw2FQt7uMDuTq5V9zyDVBtg2vd10n5Mk0vsN6607oDanSLuSUWQ
+udY5MZVC1kHfqNassPRLTHjTW6IYvx3PfQDFAZFw5AEjE8/Pz9319fWnHbB6nzvcti3jV65YA0N4
+HmruUX9mSDvXxw9YHJZlZTfJLnYB9jgsrObYsgMqQaR9BrhyWQu8O8kz1JS+B9eTHEaXcR6uF8UE
+tOTUsaobCjaUHRnt0e4nzfeVpE6NBJkKqzW1y1F4RoorWALKovhPuz671yVmpF/XNYcHAxYwENEG
+Q5xsFEua8n79xVebDXmR13lsoqXlt2tdy3GA0A6SC7syRU2LoDJMRm2PpcH8FM6dSXrf2O/GzF38
+y6XBUe5IssqnVQ1JWvpZYnZYwi1+RIjbiEYWFnguQfK+5ePg93+NGJahvTYpBc9VMp9Wwrol7DSY
+0rssa2GKX+xi+oGV3U1ASQlmD+sY3Nm6ZXTV7SyZ7k9Muq12LiIvvD8c/x3dsiWehjExDEOXvLLK
+sCTGcV3ehEDbezU1AhRr2L35RVYkflVep2l122bamC4srKjKyiVAbVsG7X5PEm+vu7g2Jyv6C1lM
+7JFgLDs8ax7DjSX1vQZKevO7B9Jd6jsDLjsSyC5bbAKK0EO9yVH5FEczsTW4p+Tr3VJ7gbXMeaAA
+RTV41kpIih2UFRQmzE6KlKRwqpKczdzhR67RYnwbDFWVR0ZenK/LcXjE9qBkl1V611UszHFJaqib
+ZNIunbJtTN0TQ6sblzst30hXMC/dPWausKSYtsuL8D4MutkmxLTONCqST2qM3fN//HMCS9lXbBHT
+xxirpqE+MXUeEEHcYB3zklBCbWyDxRYqC3NZkmSx1s3id0k4HRuwGdbs53q3dYpPWWAbW69PvOvX
+x87JFRfNa67UJtODI7Td9h8P2YOjgXg0g2Cv6wrGxHoa05jghg2VSOQm7Q8PD+o+cQ+oek/G0DWL
+hepsFgNgrdSzimIt3i5WnRqn2WDy8610F9Y2sNJxFlHUSYO6N+FUwD18CytZSpgATQKItM5qaieA
+ml4T2bGyb3C8NaU3N4lLGRbOa/Lk8MYDq+nwEZzcYcBqcq0eN4dmLeyKxcDr9Tp+5iWdZy3sw82N
+no5GUXC20bWwuCsYXe77mjp5SMoKi1VXcBaUaS5qp7AiQy1engopCrAHeugggt24u8O1VbGWLwSV
+j/kzPllhee2krHtuBU2pEpfXX5OV1bTJFjfYgvXg9h6S29Gwz7HCQHi+vpIQ8VlGbj6ORqNPL9TZ
+Cyy3xl4vl3oKCzvm8GklAWcaJVZYMElAiZqk5lyqXbF6Uj5lt0k79yrNowXUw041DYNMyfJAq7JJ
+WvJUdWO5CU3ucQp3VN4wKeszf1f7RJS5xrb+umZiUze74tG6cvcAtlllV0aGZ6sYZA1YA1tGLRaL
+3ZreTw9s/3+SJUsnJyduPBq5x/Xa5ZImtseiuiS7wuFRxFuSKSWatM41k5UM1+bS9Fms68Gb2b4+
+pss9ZAtrZW5MPnUqpqrLHGvqKfHmSXlrHUlS6in3kUkFAZKFEU6WeINVPAs4zQur6PGygP/8GLRd
+BQ0t7HG4u7tjmd3XtLDd/2l2qusigpqtKfE8cmXW+16wnSWKNSyvKZ82lRlGaerY8yUT8MdoZiUr
+A6VbyumqbNKyiqZllc66iui/npQHa8Ca/3o0obBTZoMZyxq0+KtL/L0l7j5a3SXcvFUIgVt+tPf3
+9was+wINx+UXr9tgsOv/xcUFTKnS96gkRvjHVQ14qTKphBU9LBJggpmlFeTW1oZSuzzdLawqx0Hf
+DyZFtBX4VNCmsqVI8tYFpresTjatEN8xMWdHWJJ9Npm/ukho2eMpJ6GEEsS1Rl1XMa4inrc17Ukb
+YFWHsH5pC9tLu+ge13Wt4/E41qs6jqs64Jsti5uaGH0Vxbc1i3qipwmOdv1TgUUu3yg1O0fhEScl
+oindrMTc5wSU9WayZRwvMbnC0Q8m5axRlfdNzGLzAqtuJFfQWWozwgUOuJsCIumAIAz+nYQVwrHa
+4/7D7UdQvxKsr3VftqztN/dNpvOpsP3pKAR/OhrBzk6F2y+EKrBsIlUd50Hvdmgux4HDyuBxA6xl
+gSqEq2yWGYmpN1jN+rJHeNS0BsDGwsPWIu85utIc6ZqK887hwlFbRdjR2FZA1TUB/zXxUR+5S6Ut
+4eTdAL4MrG+JN2TfI9v7z8/OJJyeWoXPNEY31omE8djpRIsTfHwWtj858Y5ZBAJAQ6wdXCyJdZqM
+f/ek3PVRldQXNbVd9F7ZKTGGqLF9iBTyrJsmPj4+6qDx2pfbJEv+xeef/Pxfx92w/nHh+4XYfuvl
+OMoDQHICNiD5cz7t55lqmpQ1T8qT33xDPopWy6VbyqMuuCkWQrH6/l7vrq9tudHtLwl0Bdi3f7dY
+1C9wr/STssuT8u+emEFl9fNKf7of7v9ve+zuK4P6EZAVYMv98lHh9UvPv9RRlXuwHIceWpdLUI5y
+lOMoj/8TYACSXxle7wvOswAAAABJRU5ErkJggg==" transform="matrix(1 0 0 1 23.509 15.5963)">
+		</image>
+		<g>
+			<g enable-background="new    ">
+				<g>
+					<polygon fill="#CCCBCE" points="237.2,5.7 237.4,7.7 140.5,7.8 140.2,5.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="140.2,5.9 140.5,7.8 85.2,55 84.9,53 					"/>
+				</g>
+				<g>
+					<polygon fill="#CCCBCE" points="84.9,53 85.2,55 81.2,55 80.9,53 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="80.9,53 81.2,55 64.4,69.3 64.1,67.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#D4D4D4" points="68.1,67.3 68.4,69.3 64.4,69.3 64.1,67.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCBCE" points="66.8,67.6 67.1,69.7 63.1,69.6 62.8,67.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="237.2,5.7 237.4,7.7 177.2,61.9 176.9,59.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="238.4,5.4 238.7,7.4 178.5,61.5 178.2,59.5 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACE" points="192.4,60 192.7,62 177.2,61.9 176.9,59.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="68.1,67.3 68.4,69.3 49.9,85.1 49.6,83 					"/>
+				</g>
+				<g>
+					<polygon fill="#E7E6EA" points="49.6,83 49.9,85.1 47.2,87.9 46.9,85.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="46.9,85.8 47.2,87.9 31.5,102.7 31.2,100.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#D3D3D3" points="37.6,100.7 38,102.7 31.5,102.7 31.2,100.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACE" points="36.4,101 36.7,103.1 30.2,103.1 29.9,101 					"/>
+				</g>
+				<g>
+					<polygon fill="#E8E7EB" points="37.6,100.7 38,102.7 29,113 28.7,110.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#D3D3D3" points="35.3,110.9 35.7,113 29,113 28.7,110.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACE" points="34,111.3 34.3,113.4 27.8,113.3 27.4,111.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="35.3,110.9 35.7,113 34,114.5 33.7,112.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#D3D3D3" points="40.2,112.4 40.5,114.5 34,114.5 33.7,112.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACD" points="39.8,112.8 40.1,114.9 32.6,114.8 32.3,112.7 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="192.4,60 192.7,62 144.7,106.8 144.3,104.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="193.7,59.6 194,61.7 146,106.4 145.7,104.3 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACD" points="162.8,104.8 163.1,107 144.7,106.8 144.3,104.6 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="165.3,102.4 165.6,104.5 163.1,107 162.8,104.8 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACE" points="181.1,102.5 181.4,104.6 165.6,104.5 165.3,102.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="181.1,102.5 181.4,104.6 174.2,111.4 173.9,109.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E5E9" points="182.4,102.1 182.7,104.2 175.5,111 175.2,108.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACE" points="187.7,109.2 188,111.4 174.2,111.4 173.9,109.2 					"/>
+				</g>
+				<g>
+					<polygon fill="#E6E6E6" points="140.2,5.9 237.2,5.7 176.9,59.8 192.4,60 144.3,104.6 162.8,104.8 165.3,102.4 181.1,102.5 
+						173.9,109.2 187.7,109.2 183,113.5 40.2,112.4 33.7,112.4 35.3,110.9 28.7,110.9 37.6,100.7 31.2,100.6 46.9,85.8 49.6,83 
+						68.1,67.3 64.1,67.3 80.9,53 84.9,53 					"/>
+				</g>
+				<g>
+					<polygon fill="#D3D3D3" points="183,113.5 183.3,115.6 40.5,114.5 40.2,112.4 					"/>
+				</g>
+				<g>
+					<polygon fill="#EFEFEF" points="187.7,109.2 188,111.4 183.3,115.6 183,113.5 					"/>
+				</g>
+				<g>
+					<path fill="#DDDCE0" d="M175.2,108.9l13.9,0l-5.5,5l-143.8-1.1l-7.5-0.1l1.7-1.4l-6.6,0l9-10.2l-6.5,0l16-15.1l2.7-2.8
+						l18.1-15.4l-4,0l17.6-15l4,0l55.3-47.1l98.7-0.1l-60.2,54.1l15.5,0.1l-48,44.6l16.5,0.2l2.5-2.4l17.7,0.1L175.2,108.9z
+						 M183,113.5l4.7-4.2l-13.9,0l7.2-6.8l-15.8-0.1l-2.5,2.4l-18.4-0.2L192.4,60l-15.5-0.1l60.2-54.1l-97,0.1L84.9,53l-4,0
+						L64.1,67.3l4,0L49.6,83l-2.7,2.8l-15.7,14.8l6.4,0l-9,10.2l6.7,0l-1.7,1.4l6.5,0L183,113.5"/>
+				</g>
+				<g>
+					<polygon fill="#E5E4E8" points="189.1,108.9 189.4,111 183.9,116 183.6,113.9 					"/>
+				</g>
+				<g>
+					<polygon fill="#CBCACD" points="183.6,113.9 183.9,116 40.1,114.9 39.8,112.8 					"/>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_156_">
+		<g id="XMLID_248_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="159.8,0.4 161,8 146.6,8 145.4,0.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="145.4,0.4 146.6,8 133.6,19.2 132.4,11.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="146.9,11.5 148.1,19.2 133.6,19.2 132.4,11.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="159.8,0.4 146.9,11.5 132.4,11.5 145.4,0.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="159.8,0.4 161,8 148.1,19.2 146.9,11.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="147.4,11.9 148.6,19.6 132.3,19.6 131.1,11.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="161.1,0 162.3,7.7 148.6,19.6 147.4,11.9 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M144.9,0l16.2,0l-13.7,11.8l-16.3,0L144.9,0z M146.9,11.5l12.9-11.2l-14.4,0l-13,11.1L146.9,11.5"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_243_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="176.2,0.4 177.4,8 162.5,8 161.3,0.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="161.3,0.4 162.5,8 149.5,19.2 148.3,11.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="163.3,11.5 164.5,19.2 149.5,19.2 148.3,11.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="176.2,0.4 177.4,8 164.5,19.2 163.3,11.5 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M160.8,0l16.7,0l-13.7,11.8l-16.8,0L160.8,0z M163.3,11.5l12.9-11.2l-14.9,0l-13,11.1L163.3,11.5"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="176.2,0.4 163.3,11.5 148.3,11.5 161.3,0.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="163.8,11.9 165,19.6 148.2,19.6 147,11.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="177.5,0 178.7,7.7 165,19.6 163.8,11.9 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_238_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="193.7,0.3 194.8,8 179,8 177.8,0.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="177.8,0.4 179,8 166,19.2 164.8,11.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="180.7,11.5 181.9,19.2 166,19.2 164.8,11.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="193.7,0.3 194.8,8 181.9,19.2 180.7,11.5 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M177.3,0L195,0l-13.7,11.8l-17.8,0L177.3,0z M180.7,11.5l12.9-11.1l-15.9,0l-13,11.1L180.7,11.5"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="193.7,0.3 180.7,11.5 164.8,11.5 177.8,0.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="181.3,11.8 182.4,19.6 164.7,19.5 163.5,11.8 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="195,0 196.1,7.7 182.4,19.6 181.3,11.8 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_232_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="234.9,0.3 236,8 207.4,8 206.2,0.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="206.2,0.3 207.4,8 200.1,14.4 199,6.8 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="227.8,6.8 228.9,14.5 200.1,14.4 199,6.8 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="234.9,0.3 227.8,6.8 199,6.8 206.2,0.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="234.9,0.3 236,8 228.9,14.5 227.8,6.8 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="228.3,7.1 229.4,14.8 198.8,14.8 197.7,7.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="236.2,0 237.3,7.7 229.4,14.8 228.3,7.1 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M205.7,0l30.5,0l-7.9,7.1l-30.6,0L205.7,0z M227.8,6.8l7.2-6.4l-28.7,0L199,6.8L227.8,6.8"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_227_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="227.2,7.2 228.3,14.9 199.4,14.9 198.3,7.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="198.3,7.2 199.4,14.9 193,20.6 191.8,12.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="220.8,12.9 222,20.7 193,20.6 191.8,12.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="227.2,7.2 220.8,12.9 191.8,12.9 198.3,7.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="227.2,7.2 228.3,14.9 222,20.7 220.8,12.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="221.4,13.3 222.5,21 191.7,21 190.5,13.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="228.5,6.9 229.6,14.6 222.5,21 221.4,13.3 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M197.8,6.9l30.7,0l-7.1,6.4l-30.8,0L197.8,6.9z M220.8,12.9l6.4-5.7l-28.9,0l-6.4,5.7L220.8,12.9"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_222_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#945B72" points="191.5,13.4 192.6,21 187.2,25.8 186.1,18.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="220.3,13.3 221.5,21 192.6,21 191.5,13.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="215,18.2 216.1,25.9 187.2,25.8 186.1,18.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="220.3,13.3 221.5,21 216.1,25.9 215,18.2 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M191,13l30.6,0l-6.1,5.5l-30.7,0L191,13z M215,18.2l5.4-4.8l-28.8,0l-5.4,4.8L215,18.2"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="220.3,13.3 215,18.2 186.1,18.2 191.5,13.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="215.5,18.5 216.6,26.2 185.9,26.2 184.8,18.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="221.6,13 222.8,20.7 216.6,26.2 215.5,18.5 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_216_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="214.5,18.5 215.6,26.2 186.7,26.2 185.6,18.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="185.6,18.5 186.7,26.2 180.3,31.9 179.1,24.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="208.2,24.2 209.3,31.9 180.3,31.9 179.1,24.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="214.5,18.5 215.6,26.2 209.3,31.9 208.2,24.2 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M185,18.2l30.8,0l-7.1,6.4l-30.9,0L185,18.2z M208.2,24.2l6.3-5.7l-29,0l-6.4,5.7L208.2,24.2"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="214.5,18.5 208.2,24.2 179.1,24.2 185.6,18.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="208.8,24.5 209.9,32.2 179,32.2 177.9,24.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="215.8,18.2 216.9,25.8 209.9,32.2 208.8,24.5 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_211_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#945B72" points="178.6,24.5 179.7,32.1 174.4,36.9 173.2,29.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="207.5,24.4 208.6,32.1 179.7,32.1 178.6,24.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="202.2,29.2 203.3,36.9 174.4,36.9 173.2,29.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="207.5,24.4 208.6,32.1 203.3,36.9 202.2,29.2 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M178.1,24.1l30.7,0l-6.1,5.5l-30.8,0L178.1,24.1z M202.2,29.2l5.3-4.8l-28.9,0l-5.4,4.7L202.2,29.2"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="207.5,24.4 202.2,29.2 173.2,29.2 178.6,24.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="202.8,29.6 203.9,37.3 173.1,37.2 171.9,29.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="208.8,24.1 209.9,31.8 203.9,37.3 202.8,29.6 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_206_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="201.9,29.4 203,37 174.2,37 173.1,29.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="173.1,29.4 174.2,37 167.8,42.8 166.6,35.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="195.5,35.1 196.6,42.8 167.8,42.8 166.6,35.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="201.9,29.4 195.5,35.1 166.6,35.1 173.1,29.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="201.9,29.4 203,37 196.6,42.8 195.5,35.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="196,35.4 197.2,43.1 166.5,43.1 165.3,35.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="203.1,29 204.3,36.7 197.2,43.1 196,35.4 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M172.6,29l30.6,0l-7.1,6.4l-30.7,0L172.6,29z M195.5,35.1l6.4-5.7l-28.8,0l-6.5,5.7L195.5,35.1"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_200_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="195.3,35.2 196.4,42.9 167.5,42.9 166.4,35.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="166.4,35.3 167.5,42.9 161.2,48.5 160,40.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="189,40.9 190.2,48.6 161.2,48.5 160,40.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="195.3,35.2 189,40.9 160,40.9 166.4,35.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="195.3,35.2 196.4,42.9 190.2,48.6 189,40.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="189.6,41.2 190.7,48.9 159.9,48.9 158.7,41.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="196.6,34.9 197.7,42.6 190.7,48.9 189.6,41.2 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M165.9,34.9l30.7,0l-7,6.3l-30.8,0L165.9,34.9z M189,40.9l6.3-5.6l-28.9,0l-6.3,5.6L189,40.9"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_195_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#945B72" points="159.7,41 160.8,48.7 155.2,53.7 154,46 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="188.7,41 189.8,48.7 160.8,48.7 159.7,41 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="183.1,46 184.2,53.7 155.2,53.7 154,46 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="188.7,41 189.8,48.7 184.2,53.7 183.1,46 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M159.2,40.7l30.8,0l-6.3,5.7l-30.9,0L159.2,40.7z M183.1,46l5.6-5l-29,0l-5.7,5L183.1,46"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="188.7,41 183.1,46 154,46 159.7,41 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="183.6,46.4 184.8,54.1 153.9,54.1 152.7,46.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="189.9,40.7 191.1,48.4 184.8,54.1 183.6,46.4 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_190_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="141.4,17.2 142.6,24.8 127.9,24.8 126.7,17.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="126.7,17.2 127.9,24.8 121.5,30.3 120.3,22.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="135,22.6 136.2,30.3 121.5,30.3 120.3,22.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="141.4,17.2 135,22.6 120.3,22.6 126.7,17.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="141.4,17.2 142.6,24.8 136.2,30.3 135,22.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="135.6,23 136.7,30.7 120.2,30.7 119,23 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="142.7,16.8 143.9,24.5 136.7,30.7 135.6,23 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M126.2,16.8l16.5,0l-7.1,6.1L119,23L126.2,16.8z M135,22.6l6.3-5.5l-14.7,0l-6.4,5.5L135,22.6"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_184_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="134.9,22.7 136,30.4 121.4,30.4 120.2,22.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="120.2,22.7 121.4,30.4 115,35.9 113.8,28.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="128.5,28.2 129.7,35.9 115,35.9 113.8,28.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="134.9,22.7 136,30.4 129.7,35.9 128.5,28.2 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M119.7,22.4l16.5,0l-7.1,6.2l-16.5,0L119.7,22.4z M128.5,28.2l6.4-5.5l-14.7,0l-6.4,5.5L128.5,28.2"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="134.9,22.7 128.5,28.2 113.8,28.2 120.2,22.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="129,28.6 130.2,36.3 113.7,36.2 112.5,28.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="136.2,22.4 137.3,30.1 130.2,36.3 129,28.6 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_179_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="156.3,16.6 157.5,24.3 144.3,24.3 143.1,16.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="143.1,16.6 144.3,24.3 130.7,36 129.5,28.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="142.8,28.3 144,36 130.7,36 129.5,28.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="156.3,16.6 142.8,28.3 129.5,28.3 143.1,16.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="156.3,16.6 157.5,24.3 144,36 142.8,28.3 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="143.3,28.6 144.5,36.3 129.4,36.3 128.2,28.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="157.6,16.3 158.8,23.9 144.5,36.3 143.3,28.6 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M142.6,16.3l15.1,0l-14.3,12.3l-15.2,0L142.6,16.3z M142.8,28.3l13.5-11.7l-13.2,0l-13.6,11.6
+							L142.8,28.3"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_174_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="120.2,34.7 121.4,42.4 107,42.4 105.9,34.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="105.9,34.7 107,42.4 100.7,47.8 99.5,40.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="113.9,40.2 115.1,47.9 100.7,47.8 99.5,40.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="120.2,34.7 113.9,40.2 99.5,40.2 105.9,34.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="120.2,34.7 121.4,42.4 115.1,47.9 113.9,40.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="114.4,40.5 115.6,48.2 99.4,48.2 98.2,40.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="121.5,34.4 122.7,42.1 115.6,48.2 114.4,40.5 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M105.4,34.4l16.1,0l-7.1,6.1l-16.2,0L105.4,34.4z M113.9,40.2l6.3-5.4l-14.3,0l-6.3,5.4L113.9,40.2"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_168_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#945B72" points="121.5,34.7 122.7,42.4 116.3,47.9 115.1,40.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="153.5,34.7 154.7,42.4 122.7,42.4 121.5,34.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="147.1,40.2 148.3,47.9 116.3,47.9 115.1,40.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="153.5,34.7 147.1,40.2 115.1,40.2 121.5,34.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="153.5,34.7 154.7,42.4 148.3,47.9 147.1,40.2 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="147.7,40.6 148.8,48.3 114.9,48.2 113.7,40.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="154.8,34.3 156,42 148.8,48.3 147.7,40.6 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M121,34.4l33.8,0l-7.2,6.2l-33.9,0L121,34.4z M147.1,40.2l6.4-5.5l-32,0l-6.5,5.5L147.1,40.2"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_163_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835065" points="113.6,40.7 114.8,48.4 100.5,48.4 99.3,40.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="99.3,40.7 100.5,48.4 94.2,53.8 93,46.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="107.3,46.1 108.5,53.8 94.2,53.8 93,46.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="113.6,40.7 107.3,46.1 93,46.1 99.3,40.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="113.6,40.7 114.8,48.4 108.5,53.8 107.3,46.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="107.9,46.4 109,54.1 92.9,54.1 91.7,46.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="114.9,40.4 116.1,48 109,54.1 107.9,46.4 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M98.8,40.4l16.1,0l-7,6.1l-16.2,0L98.8,40.4z M107.3,46.1l6.3-5.4l-14.3,0L93,46.1L107.3,46.1"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_158_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#945B72" points="114.9,40.7 116.1,48.4 109.8,53.8 108.6,46.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="146.9,40.7 148.1,48.4 116.1,48.4 114.9,40.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="140.7,46.1 141.8,53.8 109.8,53.8 108.6,46.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="146.9,40.7 140.7,46.1 108.6,46.1 114.9,40.7 						"/>
+					</g>
+					<g>
+						<polygon fill="#C56775" points="146.9,40.7 148.1,48.4 141.8,53.8 140.7,46.1 						"/>
+					</g>
+					<g>
+						<polygon fill="#835065" points="141.2,46.4 142.3,54.2 108.5,54.1 107.3,46.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="148.2,40.3 149.4,48 142.3,54.2 141.2,46.4 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M114.4,40.4l33.8,0l-7,6.1l-33.9,0L114.4,40.4z M140.7,46.1l6.2-5.4l-32,0l-6.3,5.4L140.7,46.1"/>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+	<g id="XMLID_1_">
+		<g id="XMLID_151_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="191.5,46.3 193.4,59.5 101.3,59.6 99.3,46.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="99.3,46.5 101.3,59.6 69,87.8 66.9,74.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="160.6,74.6 162.6,88.1 69,87.8 66.9,74.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="191.5,46.3 160.6,74.6 66.9,74.5 99.3,46.5 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="191.5,46.3 193.4,59.5 162.6,88.1 160.6,74.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="161.2,74.9 163.1,88.5 67.7,88.2 65.6,74.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="192.8,45.9 194.7,59.2 163.1,88.5 161.2,74.9 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M98.8,46.2l94-0.2l-31.6,29l-95.5-0.1L98.8,46.2z M160.6,74.6l30.9-28.3l-92.2,0.2l-32.4,28
+							L160.6,74.6"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_146_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="99.4,75.4 101.4,88.6 68.1,88.6 66.2,75.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="66.2,75.4 68.1,88.6 48.7,105.9 46.7,92.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="80.3,92.6 82.3,106 48.7,105.9 46.7,92.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="99.4,75.4 80.3,92.6 46.7,92.6 66.2,75.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="99.4,75.4 101.4,88.6 82.3,106 80.3,92.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="80.8,93 82.8,106.4 47.4,106.3 45.3,92.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="100.7,75 102.7,88.3 82.8,106.4 80.8,93 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M65.6,75.1l35.1-0.1L80.8,93l-35.5,0L65.6,75.1z M80.3,92.6l19.2-17.2l-33.3,0.1L46.7,92.6L80.3,92.6"
+							/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_141_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="130.4,75.4 132.3,88.6 103.4,88.6 101.4,75.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="101.4,75.4 103.4,88.6 84,106 82,92.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="111.2,92.6 113.2,106 84,106 82,92.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="130.4,75.4 132.3,88.6 113.2,106 111.2,92.6 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M100.9,75.1l30.8-0.1L111.7,93l-31.1,0L100.9,75.1z M111.2,92.6l19.2-17.2l-29,0.1L82,92.6L111.2,92.6
+							"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="130.4,75.4 111.2,92.6 82,92.6 101.4,75.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="111.7,93 113.7,106.4 82.7,106.3 80.6,92.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="131.7,75 133.6,88.3 113.7,106.4 111.7,93 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="XMLID_134_">
+			<g>
+				<g enable-background="new    ">
+					<g>
+						<polygon fill="#835165" points="161,75.4 163,88.6 134.6,88.6 132.7,75.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="132.7,75.4 134.6,88.6 115.2,106 113.2,92.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#AF5B68" points="141.9,92.6 143.8,106 115.2,106 113.2,92.6 						"/>
+					</g>
+					<g>
+						<polygon fill="#C66775" points="161,75.4 163,88.6 143.8,106 141.9,92.6 						"/>
+					</g>
+					<g>
+						<path fill="#8E576E" d="M132.1,75.1l30.2-0.1L142.4,93l-30.5,0L132.1,75.1z M141.9,92.6L161,75.4l-28.4,0.1l-19.5,17.2
+							L141.9,92.6"/>
+					</g>
+					<g>
+						<polygon fill="#BE6371" points="161,75.4 141.9,92.6 113.2,92.6 132.7,75.4 						"/>
+					</g>
+					<g>
+						<polygon fill="#835165" points="142.4,93 144.4,106.4 113.9,106.3 111.9,92.9 						"/>
+					</g>
+					<g>
+						<polygon fill="#945B72" points="162.3,75 164.3,88.3 144.4,106.4 142.4,93 						"/>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g id="clickables" opacity="0">
+	
+		<polygon id="clickable-Level_1" opacity="0.3" fill="#EF4136" stroke="#231F20" stroke-miterlimit="10" enable-background="new    " points="
+		569.3,286.1 570.8,282.8 555.6,267.5 511.3,239.8 351,246.5 338,258.7 230.5,259.5 270.3,213.6 144.5,213.6 0,339.4 0,357 
+		522.7,358.6 	"/>
+	
+		<polygon id="clickable-Level_2" opacity="0.3" fill="#EF4136" stroke="#231F20" stroke-miterlimit="10" enable-background="new    " points="
+		464.2,188.9 443.7,213.4 193.8,212.9 162.7,238.4 303.9,238.4 296.2,248.2 312.5,248.4 490,241.2 511.3,188.9 	"/>
+	
+		<polygon id="clickable-Level_3" opacity="0.3" fill="#EF4136" stroke="#231F20" stroke-miterlimit="10" enable-background="new    " points="
+		395.6,124.9 365.2,156 103.2,156.3 156,110.6 101.4,110.6 24.3,173.8 21.1,194.6 538.1,185.8 589.7,114.1 589.4,104.6 523,105.3 	
+		"/>
+	
+		<polygon id="clickable-Level_4" opacity="0.3" fill="#EF4136" stroke="#231F20" stroke-miterlimit="10" enable-background="new    " points="
+		206,99.5 161.2,99.9 253.2,0.4 138.8,0 19.3,100.6 23.3,122.1 181.7,122.1 	"/>
+</g>
+</svg>

--- a/_assets/javascripts/floor_plan.js
+++ b/_assets/javascripts/floor_plan.js
@@ -1,0 +1,65 @@
+//= require element-closest/element-closest.js
+//= require tether-tooltip/node_modules/tether/dist/js/tether.js
+//= require tether-tooltip/node_modules/tether-drop/dist/js/drop.js
+//= require tether-tooltip/dist/js/tooltip.js
+
+(function() {
+
+  function createTooltip (target, text) {
+    return new Tooltip({
+      target: target,
+      position: "top center",
+      content: text,
+      hoverOpenDelay: 50,
+      classes: "tooltip-theme-twipsy acc-floor-plan-map-tooltip"
+    });
+  }
+
+  function initClickableFloorPlan () {
+    var svg = document.querySelector("#acc-floor-plan-map > svg"),
+        nav = document.getElementById("acc-floor-plan-nav"),
+        navItems = {},
+        clickableRegex = /^clickable-/;
+
+    if (!svg || !nav) return;
+
+    Array.prototype.forEach.call(svg.children, function (element) {
+      if (clickableRegex.test(element.id)) {
+        var name = element.id.substr(10).split("_").join(" "),
+            slug = name.split(" ").join("-").toLowerCase();
+
+        var tooltip = createTooltip(element, name); // Default tooltip to layer name
+
+        var navItem = nav.querySelector("a[data-slug='" + slug + "']");
+
+        if (navItem) {
+          tooltip.content = navItem.title; // Update tooltip to match nav, if found
+
+          element.classList.add("acc-floor-plan-map-clickable");
+
+          if (location.pathname == navItem.getAttribute("href")) {
+            element.classList.add("acc-floor-plan-map-current");
+          }
+
+          navItems[element.id] = navItem; // Cache for the click handler
+        }
+      } else {
+        // Prevent mouseover on room names from hiding tooltips
+        element.style.pointerEvents = "none";
+      }
+    });
+
+    svg.addEventListener("click", function (event) {
+      var clickable = event.target.closest("[id^='clickable']");
+      if (clickable) {
+        var navItem = navItems[clickable.id];
+        if (navItem) { location.assign(navItem.href); }
+      }
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", function() {
+    initClickableFloorPlan();
+  });
+
+})();

--- a/_assets/javascripts/floor_plan.js
+++ b/_assets/javascripts/floor_plan.js
@@ -23,7 +23,10 @@
 
     if (!svg || !nav) return;
 
-    Array.prototype.forEach.call(svg.children, function (element) {
+    // Include possibly nested clickables with all first-level children
+    var children = svg.querySelectorAll("svg > *, [id^='clickable']");
+
+    Array.prototype.forEach.call(children, function (element) {
       if (clickableRegex.test(element.id)) {
         var name = element.id.substr(10).split("_").join(" "),
             slug = name.split(" ").join("-").toLowerCase();
@@ -43,7 +46,7 @@
 
           navItems[element.id] = navItem; // Cache for the click handler
         }
-      } else {
+      } else if (element.id != "clickables") {
         // Prevent mouseover on room names from hiding tooltips
         element.style.pointerEvents = "none";
       }

--- a/_assets/stylesheets/components/floor_plans.scss
+++ b/_assets/stylesheets/components/floor_plans.scss
@@ -57,3 +57,26 @@
 .acc-room-specification-list {
   border-right: 1px solid $acc-color-gray-light;
 }
+
+.acc-floor-plan-map-clickable {
+  cursor: pointer;
+  transition: fill 0.2s ease;
+
+  &:hover {
+    fill: #9E6079 !important;
+  }
+}
+
+.acc-floor-plan-map-current {
+  fill: #444046 !important;
+
+  &:hover {
+    fill: #444046 !important;
+  }
+}
+
+.tooltip-element.acc-floor-plan-map-tooltip .tooltip-content {
+  font-family: $acc-font-primary;
+  font-size: $acc-base-font-size;
+  padding: 7px 10px;
+}

--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -1,5 +1,6 @@
 //= require ./uswds
 //= require ./vendor/photoswipe
+//= require ./vendor/tooltip
 
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,600i');
 

--- a/_assets/stylesheets/vendor/tooltip.scss
+++ b/_assets/stylesheets/vendor/tooltip.scss
@@ -1,0 +1,1 @@
+//= require tether-tooltip/dist/css/tooltip-theme-twipsy

--- a/_layouts/floor_plan.html
+++ b/_layouts/floor_plan.html
@@ -41,6 +41,7 @@ layout: default
 
   <div class="usa-width-three-fourths">
     <h3>{{ page.contentful.title }}</h3>
+    {{ content }}
     {% include components/content_blocks.html blocks=page.contentful.contentBlocks %}
   </div>
 </div>

--- a/_layouts/floor_plan.html
+++ b/_layouts/floor_plan.html
@@ -9,25 +9,25 @@ layout: default
 <div class="usa-grid acc-floor-plan">
   {% if site.plans %}
     <aside class="usa-width-one-fourth">
-      <ul class="usa-sidenav-list">
+      <ul class="usa-sidenav-list" id="acc-floor-plan-nav">
         <li><a href="/facilities/plans/"{% if page.url == "/facilities/plans/" %} class="usa-current"{% endif %}>Center Overview</a></li>
 
         {% assign levels = site.plans | where_exp: "page", "page.slug contains 'level'" | sort: "slug" %}
 
         {% for level in levels %}
-          <li><a href="{{ level.url }}"{% if page.url == level.url %} class="usa-current"{% endif %}>{{ level.title }}</a></li>
+          <li><a href="{{ level.url }}"{% if page.url == level.url %} class="usa-current"{% endif %} data-slug="{{ level.slug }}" title="{{ level.title }}">{{ level.title }}</a></li>
         {% endfor %}
 
         {% for doc in site.plans %}
           {% unless doc.slug contains 'level' %}
             <li>
-              <a href="{{ doc.url }}"{% if page.url == doc.url %} class="usa-current"{% endif %}>{{ doc.title }}</a>
+              <a href="{{ doc.url }}"{% if page.url == doc.url %} class="usa-current"{% endif %} data-slug="{{ doc.slug }}" title="{{ doc.title }}">{{ doc.title }}</a>
 
               {% if doc.docs %}
                 <ul class="usa-sidenav-sub_list">
                   {% assign child_docs = doc.docs | sort: "title" %}
                   {% for child_doc in child_docs %}
-                    <a href="{{ child_doc.url }}"{% if page.url == child_doc.url %} class="usa-current"{% endif %}>{{ child_doc.title }}</a>
+                    <a href="{{ child_doc.url }}"{% if page.url == child_doc.url %} class="usa-current"{% endif %} data-slug="{{ child_doc.slug }}" title="{{ child_doc.title }}">{{ child_doc.title }}</a>
                   {% endfor %}
                 </ul>
               {% endif %}
@@ -44,3 +44,5 @@ layout: default
     {% include components/content_blocks.html blocks=page.contentful.contentBlocks %}
   </div>
 </div>
+
+{% javascript floor_plan %}

--- a/_templates/facilities/plans.html
+++ b/_templates/facilities/plans.html
@@ -1,3 +1,6 @@
 ---
 layout: floor_plan
 ---
+<div id="acc-floor-plan-map" class="acc-floor-plan-map-overview">
+  {% asset_source floor-plan-overview.svg %}
+</div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "austinconventioncenter.com",
   "dependencies": {
+    "element-closest": "^2.0.2",
     "photoswipe": "^4.1.1",
+    "tether-tooltip": "^1.2.0",
     "uswds": "^0.13.1"
   }
 }


### PR DESCRIPTION
The floor plan maps now show a tooltip w/ the room name over each
room on over, and add a hover state and click handling if a matching
page is found in the floor plan sidenav.

* I couldn't find much documentation of this, but Chrome and Safari
  seem to disallow reading an externally-hosted SVG embedded with an
  <object> tag, throwing a same-origin error despite CORS headers. So
  instead of <object> tags, the level SVGs are now just pasted into
  the corresponding textBlocks. Not ideal, maybe, but unlike directly
  adding the SVGs here, it means we don't have to maintain a room-to-
  level mapping, since the page-to-text-block relationship is kept by
  Contentful.

* Embedding the SVG directly seems like it might also provide an
  advantage over <object> in terms of interoperability with third-
  party JS (i.e. tooltip libs). I went with Hubspot's Tooltip, which
  seems to work well. The documentation of Tooltip itself is sparse,
  but it has the same options as both the underlying dep (Drop), so
  it's fairly easy to configure.