### PR TITLE
Sort section pages list by priority attribute

### DIFF
--- a/_layouts/section.html
+++ b/_layouts/section.html
@@ -10,7 +10,8 @@ layout: default
     {% if page.contentful.contentBlocks %}
       {% include components/content_blocks.html blocks=page.contentful.contentBlocks %}
     {% endif %}
-    {% for doc in page.docs %}
+    {% assign docs = page.docs | sort: "priority", "last" %}
+    {% for doc in docs %}
       <a href="{{doc.url}}" class="acc-button acc-button-primary">
         {{ doc.contentful.title }}
       </a>

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -88,6 +88,7 @@ module Jekyll
 
       doc.data["title"] = attributes["title"]
       doc.data["slug"] = slug
+      doc.data["priority"] = attributes["priority"] if attributes.key?("priority")
       doc.data["date"] = attributes["date"] if attributes.key?("date")
       doc.data["contentful"] = attributes
 


### PR DESCRIPTION
Priority is set as a number in Contentful (lower number = higher
sort). Pages without a priority sort last.