### PR TITLE
Adam thompson

### DIFF
--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -36,6 +36,7 @@
 
 }
 
+
 @media screen and (max-width: $medium-screen) {
     .acc-breadcrumb {
       display:none;

--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -33,6 +33,17 @@
     left: 100%;
     z-index: 1;
   }
+
+
+  @media screen and (max-width: $medium-screen) {
+    .acc-breadcrumb {
+      display:none;
+    }
+    .acc-breadcrumb:nth-last-child(2), .acc-breadcrumb:last-child {
+      display: block;
+    }
+  }
+
 }
 
 .acc-breadcrumb:first-child {

--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -42,7 +42,6 @@
     }
     .acc-breadcrumb:nth-last-child(2), .acc-breadcrumb:last-child {
       display: block;
-      font-size: 16px;
     }
 }
 

--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -34,16 +34,15 @@
     z-index: 1;
   }
 
+}
 
-  @media screen and (max-width: $medium-screen) {
+@media screen and (max-width: $medium-screen) {
     .acc-breadcrumb {
       display:none;
     }
     .acc-breadcrumb:nth-last-child(2), .acc-breadcrumb:last-child {
       display: block;
     }
-  }
-
 }
 
 .acc-breadcrumb:first-child {

--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -42,6 +42,7 @@
     }
     .acc-breadcrumb:nth-last-child(2), .acc-breadcrumb:last-child {
       display: block;
+      font-size: 16px;
     }
 }
 

--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -75,3 +75,9 @@
 @each $section, $color in $acc-section-colors {
   @include breadcrumb-color($color, '.#{$section}');
 }
+
+.usa-nav-container.acc-breadcrumbs-container::after {
+    display: block;
+    content: "";
+    clear: both;
+}

--- a/_assets/stylesheets/components/footer.scss
+++ b/_assets/stylesheets/components/footer.scss
@@ -109,3 +109,7 @@
 .usa-unstyled-list.usa-footer-primary-content.acc-footer-list {
     display: table;
 }
+
+.acc-footer {
+    margin-top: 30px;
+}

--- a/_assets/stylesheets/components/footer.scss
+++ b/_assets/stylesheets/components/footer.scss
@@ -38,7 +38,10 @@
 }
 
 .acc-footer-nav {
-  padding-bottom: 2em;
+    padding-bottom: 2em;
+    display: inline-block;
+    vertical-align: top;
+    max-width: 400px;
 }
 
 .acc-footer-secondary .acc-footer-nav .acc-footer-list {
@@ -101,4 +104,8 @@
   color: $acc-color-gray-light; 
   letter-spacing: .05em;
   padding-bottom: .5em;
+}
+
+.usa-unstyled-list.usa-footer-primary-content.acc-footer-list {
+    display: table;
 }

--- a/_assets/stylesheets/components/footer.scss
+++ b/_assets/stylesheets/components/footer.scss
@@ -37,6 +37,7 @@
   padding-bottom: 0;
 }
 
+
 .acc-footer-nav {
     padding-bottom: 2em;
     display: inline-block;

--- a/_assets/stylesheets/components/header.scss
+++ b/_assets/stylesheets/components/header.scss
@@ -71,7 +71,3 @@
 .acc-header .usa-menu-btn {
     margin: 0 20px 0 0;
 }
-// Breadcrumb background fix for mobile
-.usa-nav-container.acc-breadcrumbs-container {
-    display: table;
-}

--- a/_assets/stylesheets/components/header.scss
+++ b/_assets/stylesheets/components/header.scss
@@ -63,6 +63,7 @@
 
 }
 
+
 // ACC Custom Nav bar height adjustment 
 .acc-header .usa-navbar {
     height: 6rem;
@@ -71,3 +72,4 @@
 .acc-header .usa-menu-btn {
     margin: 0 20px 0 0;
 }
+

--- a/_assets/stylesheets/components/header.scss
+++ b/_assets/stylesheets/components/header.scss
@@ -62,3 +62,16 @@
   }
 
 }
+
+// ACC Custom Nav bar height adjustment 
+.acc-header .usa-navbar {
+    height: 6rem;
+}
+// Mobile menu buttom adjustments
+.acc-header .usa-menu-btn {
+    margin: 0 20px 0 0;
+}
+// Breadcrumb background fix for mobile
+.usa-nav-container.acc-breadcrumbs-container {
+    display: table;
+}

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -46,7 +46,7 @@
 
 .acc-tile-link {
   @include link-color-states($acc-color-white);
-  background-color: $acc-color-gray-lightest;
+  background-color: $acc-color-gray-dark;
   border-color: transparent;
   box-shadow: 0 0 12px #000;
   color: $acc-color-white;
@@ -73,6 +73,7 @@
     left: 0%;
     z-index: 1;
     transition: border-color $transition-time;
+    background-color: $acc-color-purple;
   }
 
   &:hover {
@@ -80,7 +81,7 @@
     background-color: $acc-color-purple;
 
     &::before {
-      border-color: $acc-color-gray;
+      border-color: $acc-color-gray-lighter;
       transition: border-color $transition-time;
     }
 

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -33,6 +33,7 @@
 .acc-homepage-tiles {
   padding: 3rem 0;
   background-color: $acc-color-gray-dark;
+  margin-bottom: -30px;
 }
 
 .acc-tiles-container {

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -46,7 +46,7 @@
 
 .acc-tile-link {
   @include link-color-states($acc-color-white);
-  background-color: $acc-color-purple;
+  background-color: $acc-color-gray-lightest;
   border-color: transparent;
   box-shadow: 0 0 12px #000;
   color: $acc-color-white;
@@ -77,7 +77,7 @@
 
   &:hover {
     @include background-color-transition;
-    background-color: $acc-color-gray-lighter;
+    background-color: $acc-color-purple;
 
     &::before {
       border-color: $acc-color-gray;

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -45,6 +45,7 @@
 
 }
 
+
 .acc-tile-link {
   @include link-color-states($acc-color-white);
   background-color: $acc-color-gray;

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -37,7 +37,8 @@
 }
 
 .acc-tiles-container {
-  margin-bottom: 1em !important;
+
+  margin: 0 auto;
   
   div {
     overflow:hidden;
@@ -93,4 +94,8 @@
 
 .acc-tiles-container:nth-child(2) .usa-width-one-third:first-child .acc-tile-link {
     padding: .5em 0em 0 1.5em;
+}
+
+.acc-tiles-container .usa-width-one-third {
+    margin-bottom: 15px;
 }

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -75,7 +75,7 @@
     left: 0%;
     z-index: 1;
     transition: border-color $transition-time;
-    background-color: $acc-color-purple;
+    border-color: $acc-color-purple;
   }
 
   &:hover {

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -78,7 +78,7 @@
 
   &:hover {
     @include background-color-transition;
-    background-color: $acc-color-purple;
+    border-color: $acc-color-purple;
 
     &::before {
       border-color: $acc-color-gray-lighter;

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -46,7 +46,7 @@
 
 .acc-tile-link {
   @include link-color-states($acc-color-white);
-  background-color: $acc-color-gray;
+  background-color: $acc-color-purple;
   border-color: transparent;
   box-shadow: 0 0 12px #000;
   color: $acc-color-white;
@@ -77,7 +77,7 @@
 
   &:hover {
     @include background-color-transition;
-    background-color: $acc-color-gray-dark;
+    background-color: $acc-color-gray-lighter;
 
     &::before {
       border-color: $acc-color-gray;
@@ -86,4 +86,8 @@
 
   }
 
+}
+
+.acc-tiles-container:nth-child(2) .usa-width-one-third:first-child .acc-tile-link {
+    padding: .5em 0em 0 1.5em;
 }

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -37,8 +37,7 @@
 }
 
 .acc-tiles-container {
-
-  margin: 0 auto;
+  margin-bottom: 1em !important;
   
   div {
     overflow:hidden;
@@ -94,8 +93,4 @@
 
 .acc-tiles-container:nth-child(2) .usa-width-one-third:first-child .acc-tile-link {
     padding: .5em 0em 0 1.5em;
-}
-
-.acc-tiles-container .usa-width-one-third {
-    margin-bottom: 15px;
 }

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -46,7 +46,7 @@
 
 .acc-tile-link {
   @include link-color-states($acc-color-white);
-  background-color: $acc-color-gray-dark;
+  background-color: $acc-color-gray;
   border-color: transparent;
   box-shadow: 0 0 12px #000;
   color: $acc-color-white;

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -80,7 +80,7 @@
 
   &:hover {
     @include background-color-transition;
-    border-color: $acc-color-purple;
+    background-color: $acc-color-purple;
 
     &::before {
       border-color: $acc-color-gray-lighter;

--- a/_assets/stylesheets/variables/all.scss
+++ b/_assets/stylesheets/variables/all.scss
@@ -9,6 +9,7 @@ $site: config_value("id");
 // Colors
 $acc-color-gray: #5E5B60;
 $acc-color-gray-light: #D8D3DD;
+$acc-color-gray-lighter: #EAEAEA;
 $acc-color-gray-lightest: #F5F4F8;
 $acc-color-gray-dark: #444046;
 
@@ -19,6 +20,8 @@ $acc-color-orange: #FB6F64;
 $acc-color-green: #75A973;
 
 $acc-color-violet: #676389;
+
+$acc-color-purple: #7C70BD;
 
 $acc-color-teal: #00807A;
 $acc-color-teal-dark: #1D6464;

--- a/_assets/stylesheets/variables/all.scss
+++ b/_assets/stylesheets/variables/all.scss
@@ -6,6 +6,19 @@ $site: config_value("id");
   // do something else
 }
 
+// ACC Custom Nav bar height adjustment 
+.acc-header .usa-navbar {
+    height: 6rem;
+}
+// Mobile menu buttom adjustments
+.acc-header .usa-menu-btn {
+    margin: 0 20px 0 0;
+}
+// Breadcrumb background fix for mobile
+.usa-nav-container.acc-breadcrumbs-container {
+    display: table;
+}
+
 // Colors
 $acc-color-gray: #5E5B60;
 $acc-color-gray-light: #D8D3DD;

--- a/_assets/stylesheets/variables/all.scss
+++ b/_assets/stylesheets/variables/all.scss
@@ -6,19 +6,6 @@ $site: config_value("id");
   // do something else
 }
 
-// ACC Custom Nav bar height adjustment 
-.acc-header .usa-navbar {
-    height: 6rem;
-}
-// Mobile menu buttom adjustments
-.acc-header .usa-menu-btn {
-    margin: 0 20px 0 0;
-}
-// Breadcrumb background fix for mobile
-.usa-nav-container.acc-breadcrumbs-container {
-    display: table;
-}
-
 // Colors
 $acc-color-gray: #5E5B60;
 $acc-color-gray-light: #D8D3DD;

--- a/_assets/stylesheets/variables/all.scss
+++ b/_assets/stylesheets/variables/all.scss
@@ -10,7 +10,9 @@ $site: config_value("id");
 $acc-color-gray: #5E5B60;
 $acc-color-gray-light: #D8D3DD;
 $acc-color-gray-lighter: #EAEAEA;
+
 $acc-color-gray-lightest: #F5F4F8;
+
 $acc-color-gray-dark: #444046;
 
 $acc-color-red: #D36E7D;

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer class="usa-footer usa-footer-medium acc-footer" role="contentinfo">
-  <div class="usa-grid usa-footer-return-to-top">
+  <!--<div class="usa-grid usa-footer-return-to-top">
     <a href="#">Return to top</a>
-  </div>
+  </div>-->
   <div class="usa-footer-primary-section acc-footer-secondary">
     <div class="usa-grid-full">
       <nav class="usa-footer-nav acc-footer-nav usa-width-one-fourth">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,7 @@
 <footer class="usa-footer usa-footer-medium acc-footer" role="contentinfo">
+  <!--<div class="usa-grid usa-footer-return-to-top">
+    <a href="#">Return to top</a>
+  </div>-->
   <div class="usa-footer-primary-section acc-footer-secondary">
     <div class="usa-grid-full">
       <nav class="usa-footer-nav acc-footer-nav usa-width-one-fourth">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,4 @@
 <footer class="usa-footer usa-footer-medium acc-footer" role="contentinfo">
-  <!--<div class="usa-grid usa-footer-return-to-top">
-    <a href="#">Return to top</a>
-  </div>-->
   <div class="usa-footer-primary-section acc-footer-secondary">
     <div class="usa-grid-full">
       <nav class="usa-footer-nav acc-footer-nav usa-width-one-fourth">


### PR DESCRIPTION
Changes the homepage tiles to a purple on hover that corresponds with the banner image.  I think the color looks better than just going to darker gray.  I fixed up the responsive spacing of the buttons on smaller screens as well.

I added CSS when screen size is under 600px to hide all breadcrumbs except the current page and it's parent, if it has one.  The font size scales down to 14px to help the potential 2 tabs fit better.

Added footer responsive css to make the quick nav lists line up better.  

Removed the back to top link.