### PR TITLE
Home page tile cleanup, Footer nav fix, Breadcrumb responsiveness

### DIFF
--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -75,3 +75,12 @@
 @each $section, $color in $acc-section-colors {
   @include breadcrumb-color($color, '.#{$section}');
 }
+
+@media screen and (max-width: $medium-screen) {
+    .acc-breadcrumb {
+      display:none;
+    }
+    .acc-breadcrumb:last-child {
+      display: block;
+    }
+}

--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -33,6 +33,17 @@
     left: 100%;
     z-index: 1;
   }
+
+}
+
+@media screen and (max-width: $medium-screen) {
+    .acc-breadcrumb {
+      display:none;
+    }
+    .acc-breadcrumb:nth-last-child(2), .acc-breadcrumb:last-child {
+      display: block;
+      font-size: 16px;
+    }
 }
 
 .acc-breadcrumb:first-child {
@@ -76,11 +87,21 @@
   @include breadcrumb-color($color, '.#{$section}');
 }
 
+<<<<<<< HEAD
 @media screen and (max-width: $medium-screen) {
     .acc-breadcrumb {
       display:none;
     }
     .acc-breadcrumb:last-child {
       display: block;
+      font-size: 14px;
     }
+}
+
+=======
+>>>>>>> 948296c... Breadcrumb fixes
+.usa-nav-container.acc-breadcrumbs-container::after {
+    display: block;
+    content: "";
+    clear: both;
 }

--- a/_assets/stylesheets/components/footer.scss
+++ b/_assets/stylesheets/components/footer.scss
@@ -38,7 +38,17 @@
 }
 
 .acc-footer-nav {
+<<<<<<< HEAD
   padding-bottom: 2em;
+  display: inline-block;
+  vertical-align: top;
+  max-width: 400px;
+=======
+    padding-bottom: 2em;
+    display: inline-block;
+    vertical-align: top;
+    max-width: 400px;
+>>>>>>> ec9c300... Footer Nav list alignment
 }
 
 .acc-footer-secondary .acc-footer-nav .acc-footer-list {
@@ -101,4 +111,18 @@
   color: $acc-color-gray-light; 
   letter-spacing: .05em;
   padding-bottom: .5em;
+}
+<<<<<<< HEAD
+.acc-footer {
+    margin-top: 30px;
+}
+=======
+
+>>>>>>> ec9c300... Footer Nav list alignment
+.usa-unstyled-list.usa-footer-primary-content.acc-footer-list {
+    display: table;
+}
+
+.acc-footer {
+    margin-top: 30px;
 }

--- a/_assets/stylesheets/components/header.scss
+++ b/_assets/stylesheets/components/header.scss
@@ -62,3 +62,12 @@
   }
 
 }
+
+// ACC Custom Nav bar height adjustment 
+.acc-header .usa-navbar {
+    height: 6rem;
+}
+// Mobile menu buttom adjustments
+.acc-header .usa-menu-btn {
+    margin: 0 20px 0 0;
+}

--- a/_assets/stylesheets/components/homepage.scss
+++ b/_assets/stylesheets/components/homepage.scss
@@ -33,10 +33,16 @@
 .acc-homepage-tiles {
   padding: 3rem 0;
   background-color: $acc-color-gray-dark;
+  margin-bottom: -30px;
 }
 
+//Tile margin fix
 .acc-tiles-container {
-  margin-bottom: 1em !important;
+<<<<<<< HEAD
+=======
+
+>>>>>>> 6dd1acb... Home Tile CSS
+  margin: 0 auto;
   
   div {
     overflow:hidden;
@@ -44,6 +50,7 @@
 
 }
 
+//Button color changes to match the banner picture purple
 .acc-tile-link {
   @include link-color-states($acc-color-white);
   background-color: $acc-color-gray;
@@ -73,17 +80,43 @@
     left: 0%;
     z-index: 1;
     transition: border-color $transition-time;
+<<<<<<< HEAD
+<<<<<<< HEAD
+    border-color: $acc-color-purple;
+=======
+    background-color: $acc-color-purple;
+>>>>>>> a373e60... Homepage Tile CSS
+=======
+    border-color: $acc-color-purple;
+>>>>>>> 5c631e8... Homepage CSS Changes
   }
 
   &:hover {
     @include background-color-transition;
-    background-color: $acc-color-gray-dark;
+    background-color: $acc-color-purple;
 
     &::before {
-      border-color: $acc-color-gray;
+      border-color: $acc-color-gray-lighter;
       transition: border-color $transition-time;
     }
 
   }
 
+}
+
+//Tile padding fix, looks nicer in mobile
+.acc-tiles-container:nth-child(2) .usa-width-one-third:first-child .acc-tile-link {
+    padding: .5em 0em 0 1.5em;
+}
+
+<<<<<<< HEAD
+<<<<<<< HEAD
+//Adds a mobile fix so they aren't stacked directly on top of each other
+=======
+>>>>>>> 6dd1acb... Home Tile CSS
+=======
+//Adds a mobile fix so they aren't stacked directly on top of each other
+>>>>>>> d95cb7a... Home page tile clean up and responsive fixes
+.acc-tiles-container .usa-width-one-third {
+    margin-bottom: 15px;
 }

--- a/_assets/stylesheets/variables/all.scss
+++ b/_assets/stylesheets/variables/all.scss
@@ -9,7 +9,9 @@ $site: config_value("id");
 // Colors
 $acc-color-gray: #5E5B60;
 $acc-color-gray-light: #D8D3DD;
+
 $acc-color-gray-lightest: #F5F4F8;
+
 $acc-color-gray-dark: #444046;
 
 $acc-color-red: #D36E7D;

--- a/_assets/stylesheets/variables/all.scss
+++ b/_assets/stylesheets/variables/all.scss
@@ -9,6 +9,10 @@ $site: config_value("id");
 // Colors
 $acc-color-gray: #5E5B60;
 $acc-color-gray-light: #D8D3DD;
+<<<<<<< HEAD
+=======
+$acc-color-gray-lighter: #EAEAEA;
+>>>>>>> 1a0140b... Purple and lighter gray add in
 
 $acc-color-gray-lightest: #F5F4F8;
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,4 @@
 <footer class="usa-footer usa-footer-medium acc-footer" role="contentinfo">
-  <div class="usa-grid usa-footer-return-to-top">
-    <a href="#">Return to top</a>
-  </div>
   <div class="usa-footer-primary-section acc-footer-secondary">
     <div class="usa-grid-full">
       <nav class="usa-footer-nav acc-footer-nav usa-width-one-fourth">


### PR DESCRIPTION
I was trying to separate out all of my changes into a few different branches as per requested but it's proving a little more tedious.  I hope this is ok that they all come through in this pr.

Home page tiles:
 - They line up nicely and stack well on smaller devices
 - They have coloring matching the banner image

Footer nav:
 - Footer nav stacks nicely on mobile devices

Breadcrumbs:
 - Breadcrumbs should only show the current page and/or the parent on smaller devices.  (This worked for me but Jake said it wasn't for him...  may need a tweak)

