### PR TITLE
Match color and type styles to latest specs

### DIFF
--- a/_assets/stylesheets/components/floor_plans.scss
+++ b/_assets/stylesheets/components/floor_plans.scss
@@ -94,7 +94,7 @@
 }
 
 .tooltip-element.acc-floor-plan-map-tooltip .tooltip-content {
-  font-family: $acc-font-primary;
-  font-size: $acc-base-font-size;
+  font-family: $font-sans;
+  font-size: $base-font-size;
   padding: 7px 10px;
 }

--- a/_assets/stylesheets/components/header.scss
+++ b/_assets/stylesheets/components/header.scss
@@ -18,9 +18,9 @@
   @include link-color-states($acc-color-gray-dark);
   color: $acc-color-gray-dark;
   font-size: 1.5rem;
-  font-weight: $acc-weight-bold;
+  font-weight: 600;
   transition: color $transition-time;
-  
+
   span {
     border-bottom: .3rem solid $acc-color-white;
     border-width: .3rem;
@@ -32,7 +32,7 @@
     border-bottom: .3rem solid $acc-color-teal;
     transition: border-bottom $transition-time;
   }
-  
+
   &:hover {
     color: $acc-color-teal;
     transition: color $transition-time;
@@ -40,7 +40,6 @@
 }
 
 .acc-header {
-  margin-bottom: 4.8rem;
   border-bottom: none;
 }
 
@@ -49,12 +48,12 @@
   padding: .25em;
   color: white;
   font-size: 1.2rem;
-  
+
   a {
     @include link-color-states(white);
     color: white;
     text-decoration: underline;
-    
+
     &:hover {
       text-decoration: underline;
     }

--- a/_assets/stylesheets/components/sidebar.scss
+++ b/_assets/stylesheets/components/sidebar.scss
@@ -3,7 +3,6 @@ aside {
 }
 
 aside h3 {
-  font-weight: $acc-weight-normal;
   padding: 2rem 2rem .5rem 2rem;
   margin: 0;
 }
@@ -31,7 +30,7 @@ aside h3 {
 }
 
 .acc-sidebar-email-link {
-  font-weight: $acc-weight-bold;
+  font-weight: 600;
 }
 
 .acc-sidebar-links {

--- a/_assets/stylesheets/elements/buttons.scss
+++ b/_assets/stylesheets/elements/buttons.scss
@@ -2,14 +2,14 @@
   @include background-color-transition;
   background-repeat: no-repeat;
   background-size: 1.6em;
-  border-radius: $acc-border-radius;
+  border-radius: 1rem;
   display: block;
   font-size: 1.5rem;
-  font-weight: $acc-weight-bold;
+  font-weight: 600;
   padding: 1em;
   text-align: center;
   text-decoration: none;
-  
+
   &:hover {
     @include background-color-transition;
   }
@@ -21,7 +21,7 @@
   @include link-color-states($acc-color-white);
   background-color: $acc-color-teal;
   color: $acc-color-white;
-  
+
   &:hover {
     @include background-color-transition;
     background-color: $acc-color-teal-dark;
@@ -38,10 +38,10 @@
   border-bottom: 2px solid white;
   border-radius: 0;
   font-size: $h2-font-size;
-  font-weight: $acc-weight-light;
+  font-weight: 300;
   padding: 1em 2em 1em 1em;
   text-align:left;
-  
+
   &:hover {
     @include background-color-transition;
     background-color: $acc-color-teal-light;
@@ -54,12 +54,12 @@
   background-color: $acc-color-white;
   background-position: 95% center;
   background-repeat: no-repeat;
-  border: 2px solid $acc-border-color;
+  border: 2px solid $acc-color-gray-light;
   color: $acc-color-gray;
   margin-bottom: 1rem;
   padding-right: 3em;
   text-align: left;
-  
+
   &:hover {
     background-color: $acc-color-gray-lightest;
   }

--- a/_assets/stylesheets/elements/typography.scss
+++ b/_assets/stylesheets/elements/typography.scss
@@ -1,54 +1,42 @@
 body {
   color: $acc-color-gray;
-  font-family: $acc-font-primary;
-  font-size: $acc-base-font-size;
-  font-weight: normal;
 }
 
-h1, h2, h3 {
-  color: $acc-color-gray;
-  font-family: $acc-font-primary;
-
+h1, h2, h3, h4, h5, h6 {
+  color: $acc-color-gray-dark;
 }
+
 h1 {
-  font-weight: $acc-weight-light;
-  padding-bottom: .5em;
+  font-weight: 400;
 }
 
 h2 {
-  font-weight: $acc-weight-light;
-  margin-top: 0;
+  font-weight: 300;
 }
 
 h3 {
-  font-weight: $acc-weight-bold;
+  font-weight: 600;
+  margin-top: 3em;
 }
 
 h4 {
-  font-size: 1.5rem;
-  font-weight: $acc-weight-bold;
+  font-weight: 600;
+  letter-spacing: 0.5px;
   text-transform: uppercase;
-  color: $acc-color-gray-light;
-  font-family: $acc-font-primary;
 }
 
 p {
-  margin-top: .5em;
+  margin-top: 0.5em;
 }
 
 a {
-  color: $acc-link-color;
+  color: $acc-color-teal;
+  text-decoration: underline;
   transition: color $transition-time;
-  
-  &:active, &:visited {
-    color: $acc-link-color;
-  }
-  
-  &:hover {
-    color: $acc-link-hover-color;
-    transition: color $transition-time;
-  }
 
+  &:hover {
+    color: $acc-color-teal-dark;
+  }
 }
 
 .acc-content-block-list ul {

--- a/_assets/stylesheets/variables/all.scss
+++ b/_assets/stylesheets/variables/all.scss
@@ -7,48 +7,28 @@ $site: config_value("id");
 }
 
 // Colors
-$acc-color-gray: #5E5B60;
-$acc-color-gray-light: #D8D3DD;
-$acc-color-gray-lightest: #F5F4F8;
-$acc-color-gray-dark: #444046;
-
-$acc-color-red: #D36E7D;
-
-$acc-color-orange: #FB6F64;
-
-$acc-color-green: #75A973;
-
-$acc-color-violet: #676389;
-
-$acc-color-teal: #00807A;
-$acc-color-teal-dark: #1D6464;
-$acc-color-teal-light: #C2F6EC;
-
-$acc-color-white: #FFFFFF;
-
-$acc-link-color: $acc-color-teal;
-$acc-link-hover-color: $acc-color-teal-dark;
+$acc-color-white:  #ffffff;
+$acc-color-gray-lightest: #f5f4f8;
+$acc-color-gray-light: #b3adb8;
+$acc-color-gray: #5e5b60;
+$acc-color-gray-dark: #282629;
+$acc-color-red: #d36e7d;
+$acc-color-orange: #f57066;
+$acc-color-green: #689671;
+$acc-color-violet: #7f7285;
+$acc-color-teal-light: #c2f6ec;
+$acc-color-teal: #00807a;
+$acc-color-teal-dark: #1d6464;
 
 // Typography
 $acc-font-primary: "Open Sans", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
 
-$acc-base-font-size: 1.7rem;
-$acc-weight-light: 300;
-$acc-weight-normal: 400;
-$acc-weight-bold: 600;
-
-$acc-color-base: $acc-color-gray;
-
 $acc-section-colors: (
   'facilities': $acc-color-red,
   'services': $acc-color-orange,
-  'visiting': $acc-color-teal
+  'visiting': $acc-color-green
 );
 
-$transition-time: .5s;
-
-$acc-border-radius: 1rem;
-
-$acc-border-color: $acc-color-gray-light;
+$transition-time: 0.5s;
 
 @import "uswds";

--- a/_assets/stylesheets/variables/uswds.scss
+++ b/_assets/stylesheets/variables/uswds.scss
@@ -12,16 +12,17 @@ $small-font-size: rem(14px);
 $lead-font-size: rem(20px);
 $title-font-size: rem(52px);
 $h1-font-size: rem(44px);
-$h2-font-size: rem(30px);
+$h2-font-size: rem(28px);
 $h3-font-size: rem(20px);
-$h4-font-size: rem(17px);
-$h5-font-size: rem(15px);
+$h4-font-size: rem(15px);
+$h5-font-size: rem(14px);
 $h6-font-size: rem(13px);
 $base-line-height: 1.5;
 $heading-line-height: 1.3;
 $lead-line-height: 1.7;
 
 $font-sans: $acc-font-primary;
+$font-serif: $acc-font-primary;
 
 $font-normal: 400;
 $font-bold: 700;
@@ -44,7 +45,7 @@ $color-secondary-light: #e59393; // lighten($color-secondary, 60%)
 $color-secondary-lightest: #f9dede; // lighten($color-secondary, 90%)
 
 $color-white: #ffffff;
-$color-base: $acc-color-base;
+$color-base: $acc-color-gray;
 $color-black: #000000;
 
 $color-gray-dark: #323a45;
@@ -73,8 +74,8 @@ $color-cool-blue-light: #4773aa; // lighten($color-cool-blue, 20%)
 $color-cool-blue-lighter: #8ba6ca; // lighten($color-cool-blue, 60%)
 $color-cool-blue-lightest: #dce4ef; // lighten($color-cool-blue, 90%)
 
-$color-focus: #3e94cf;
-$color-visited: #4c2c92;
+$color-focus: $acc-color-teal;
+$color-visited: $acc-color-teal;
 
 $color-shadow: rgba(#000, 0.3);
 

--- a/_layouts/floor_plan.html
+++ b/_layouts/floor_plan.html
@@ -1,12 +1,12 @@
 ---
 layout: default
 ---
-
-<div class="usa-grid">
-  <h1>Floor Plans</h1>
-</div>
-
 <div class="usa-grid acc-floor-plan">
+  <div class="usa-width-one-whole">
+    <header>
+      <h1>{{ page.contentful.title }}</h1>
+    </header>
+  </div>
   {% if site.plans %}
     <aside class="usa-width-one-fourth">
       <nav role="navigation" class="acc-sidenav" id="sidenav">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,12 +3,11 @@ layout: default
 ---
 
 <div class="usa-grid">
-  {% if page.contentful.coverImage != nil %}
-    <img src="{{ page.contentful.coverImage.url }}" alt="Banner image" class="acc-banner-image" />
-  {% endif %}
-  <h1>{{ page.contentful.title }}</h1>
-</div>
-<div class="usa-grid">
+  <div class="usa-width-one-whole">
+    <header>
+      <h1>{{ page.contentful.title }}</h1>
+    </header>
+  </div>
   <div class="usa-width-two-thirds">
     <div>
       {% include components/content_blocks.html blocks=page.contentful.contentBlocks %}

--- a/_layouts/section.html
+++ b/_layouts/section.html
@@ -3,9 +3,11 @@ layout: default
 ---
 
 <div class="usa-grid">
-  <h1>{{page.contentful.title}}</h1>
-</div>
-<div class="usa-grid">
+  <div class="usa-width-one-whole">
+    <header>
+      <h1>{{ page.contentful.title }}</h1>
+    </header>
+  </div>
   <div class="usa-width-two-thirds">
     {% if page.contentful.contentBlocks %}
       {% include components/content_blocks.html blocks=page.contentful.contentBlocks %}


### PR DESCRIPTION
Removes some of the $acc- variables that weren't widely used, and
moves toward using USWDS variables instead of overriding tag styles
(such as for the header fonts).

I've also moved the page-title H1s, which were children of `usa-
grid`, into `usa-width-one-whole` within the page's main `usa-grid`,
and then within semantic `<header>` tags, so the H1 margins are no
longer removed by grid-related first-child/last-child rules.