### PR TITLE
Fix a couple breadcrumb display bugs

### DIFF
--- a/_assets/stylesheets/components/breadcrumbs.scss
+++ b/_assets/stylesheets/components/breadcrumbs.scss
@@ -2,19 +2,23 @@
   background-color: $acc-color-orange;
 }
 
+.acc-breadcrumb-container {
+  display: flex;
+  flex-direction: row;
+}
+
 .acc-breadcrumb {
   $height: 4rem;
   background-color: transparent;
   border-color: transparent;
   color: white;
   display: block;
-  float: left;
   font-size: 2rem;
   height: $height;
   line-height: $height;
-  padding: 0 1.7em 0 2.5em;
   position: relative;
   text-decoration: none;
+  white-space: nowrap;
   -webkit-font-smoothing: antialiased;
 
   &:active, &:hover, &:visited {
@@ -36,10 +40,11 @@
     z-index: 1;
   }
 
-  @media screen and (min-width: $small-screen) {
+  @media screen and (min-width: $nav-width) {
     $height: 6rem;
     height: $height;
     line-height: $height;
+    padding: 0 1.5em 0 2em;
 
     &::after {
       $border-width: $height / 2;
@@ -50,7 +55,7 @@
 
 @mixin breadcrumb-level($color, $index) {
   .acc-breadcrumb:nth-last-child(#{$index}) {
-    @media screen and (min-width: $small-screen) {
+    @media screen and (min-width: $nav-width) {
       $color: mix(#3c3c3c, $color, $index * 10%);
       background-color: $color;
       border-color: $color;
@@ -63,9 +68,9 @@
 }
 
 .acc-breadcrumb:first-child {
-  padding-left: 0;
+  @media screen and (min-width: $nav-width) {
+    padding-left: 0;
 
-  @media screen and (min-width: $small-screen) {
     &::before {
       background-color: inherit;
       content: '';
@@ -82,7 +87,7 @@
 .acc-breadcrumb:not(.acc-breadcrumb-mobile) {
   display: none;
 
-  @media screen and (min-width: $small-screen) {
+  @media screen and (min-width: $nav-width) {
     display: block;
   }
 }
@@ -94,7 +99,7 @@ a.acc-breadcrumb-mobile {
   background-size: 0.5em;
   text-indent: 1em;
 
-  @media screen and (min-width: $small-screen) {
+  @media screen and (min-width: $nav-width) {
     background-image: none;
     text-indent: 0;
   }

--- a/_includes/components/breadcrumbs.html
+++ b/_includes/components/breadcrumbs.html
@@ -1,5 +1,5 @@
 <div class="acc-breadcrumbs {{ page.breadcrumbs[0].slug }}">
-  <div class="usa-grid">
+  <div class="usa-grid acc-breadcrumb-container">
     {% for breadcrumb in page.breadcrumbs %}
       {% capture breadcrumb_class %}acc-breadcrumb{% if forloop.length == 1 or forloop.rindex == 2 %} acc-breadcrumb-mobile{% endif %}{% endcapture %}
 


### PR DESCRIPTION
* Switches from float to flexbox to prevent wrapping in the event of
  having too many breadcrumbs to fit horizontally, but also changes
  the mobile breakpoint to the more conservative $nav-width, which
  makes the too-many case much less likely.

* Corrects the left-padding of the mobile breadcrumb when it's not
  the first child.