### PR TITLE
Switch responsive primary navigation to hamburger/slideout pattern

### DIFF
--- a/_assets/javascripts/components/nav.js
+++ b/_assets/javascripts/components/nav.js
@@ -1,0 +1,11 @@
+function toggleNav (event) {
+  document.querySelector(".acc-nav-button").classList.toggle("is-active");
+  document.querySelector(".acc-nav").classList.toggle("is-visible");
+  event.preventDefault();
+}
+
+function navInit (delegate) {
+  delegate.on("click", ".acc-nav-button", toggleNav);
+}
+
+module.exports.init = navInit;

--- a/_assets/javascripts/main.js
+++ b/_assets/javascripts/main.js
@@ -3,11 +3,13 @@
 
 var delegate = require("dom-delegate"), // https://github.com/ftlabs/ftdomdelegate
     folders = require("components/folders"),
+    nav = require("components/nav"),
     sidenav = require("components/sidenav");
 
 document.addEventListener("DOMContentLoaded", function() {
   var mainDelegate = delegate(document);
 
   folders.init(mainDelegate);
+  nav.init(mainDelegate);
   sidenav.init(mainDelegate);
 });

--- a/_assets/stylesheets/components/header.scss
+++ b/_assets/stylesheets/components/header.scss
@@ -1,41 +1,118 @@
+.acc-header-content {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  position: relative;
+  height: 9rem;
+
+  @media screen and (min-width: $nav-width) {
+    height: 11rem;
+  }
+}
+
+.acc-nav-button {
+  width: auto;
+
+  &:active {
+    background-color: transparent;
+  }
+
+  @media screen and (min-width: $nav-width) {
+    display: none;
+  }
+}
+
+.acc-nav {
+  background-color: $acc-color-white;
+  box-shadow: 0 2px 1px rgba(#000, 0.3);
+  width: 100%;
+  max-height: 0;
+  overflow-y: hidden;
+  position: absolute;
+  top: 9rem;
+  left: 0;
+  transition: max-height 0.25s ease-out;
+  z-index: 100;
+
+  &.is-visible {
+    max-height: 31rem; // ~ 6 items
+    overflow-y: auto;
+    transition: max-height 0.25s ease-in;
+  }
+
+  @media screen and (min-width: $nav-width) {
+    box-shadow: none;
+    max-height: unset;
+    overflow-y: visible;
+    position: unset;
+    width: auto;
+  }
+}
+
+.acc-nav-list {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0;
+
+  @media screen and (min-width: $nav-width) {
+    flex-direction: row;
+  }
+}
+
+.acc-nav-link {
+  display: block;
+  font-size: $h4-font-size;
+  font-weight: 600;
+  color: $acc-color-gray-dark;
+  padding: 1.3rem $site-margins-mobile 1.7rem;
+  text-decoration: none;
+
+  @media screen and (min-width: $medium-screen) and (max-width: $nav-width) {
+    padding-left: $site-margins;
+    padding-right: $site-margins;
+  }
+
+  span {
+    border-left: 3px solid transparent;
+    padding: 0.25rem 0 0.25rem 1rem;
+    margin-left: calc(-1rem - 3px);
+    transition: border-color 0.15s;
+  }
+
+  @media screen and (min-width: $nav-width) {
+    span {
+      margin-left: 0;
+      padding: 0 0 0.25rem 0;
+      border-left: none;
+      border-bottom: 3px solid transparent;
+    }
+  }
+
+  &:visited, &:active {
+    color: $acc-color-gray-dark;
+  }
+
+  &:hover {
+    color: $acc-color-teal;
+
+    span {
+      border-color: $acc-color-teal;
+    }
+  }
+}
+
 .acc-logo {
-  float: left;
-  margin: 3rem 0;
+  flex: 1 0 auto;
 
   a {
-    display: block;
+    display: inline-block;
   }
 
   img {
     height: 5rem;
   }
 }
-
-.acc-nav-primary .acc-nav-link {
-  @include link-color-states($acc-color-gray-dark);
-  color: $acc-color-gray-dark;
-  font-size: 1.5rem;
-  font-weight: 600;
-  transition: color $transition-time;
-
-  span {
-    border-bottom: .3rem solid $acc-color-white;
-    border-width: .3rem;
-    padding-bottom: .25rem;
-    transition: border-bottom $transition-time;
-  }
-
-  &:hover span {
-    border-bottom: .3rem solid $acc-color-teal;
-    transition: border-bottom $transition-time;
-  }
-
-  &:hover {
-    color: $acc-color-teal;
-    transition: color $transition-time;
-  }
-}
-
 
 .acc-disclaimer {
   background-color: $acc-color-red;

--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -1,5 +1,6 @@
 //= require ./uswds
 //= require ./vendor/font_awesome
+//= require ./vendor/hamburgers
 //= require ./vendor/photoswipe
 //= require ./vendor/tooltip
 

--- a/_assets/stylesheets/vendor/hamburgers.scss
+++ b/_assets/stylesheets/vendor/hamburgers.scss
@@ -1,0 +1,5 @@
+$hamburger-layer-width: 30px;
+$hamburger-hover-opacity: 1.0;
+$hamburger-types: (slider);
+
+@import "hamburgers/_sass/hamburgers/hamburgers";

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,24 +7,24 @@
   </header>
 </div>
 <header class="acc-header" role="banner">
-  <div class="usa-grid">
-    <button class="usa-menu-btn">Menu</button>
+  <div class="usa-grid acc-header-content">
+    <!-- <button class="usa-menu-btn">Menu</button> -->
     <div class="acc-logo">
       <a href="{{site.baseurl}}/" accesskey="1" title="Home" aria-label="Home">
         <img src="{% asset_path acc-logo.svg %}" />
       </a>
     </div>
-    <nav role="navigation" class="usa-nav acc-nav" id="nav">
-      <button class="usa-nav-close">
-        <img src="{% asset_path uswds/src/img/close.svg %}" alt="close">
-      </button>
-      <ul class="usa-nav-primary acc-nav-primary">
+    <button class="usa-button-unstyled acc-nav-button hamburger hamburger--slider" type="button">
+      <span class="hamburger-box">
+        <span class="hamburger-inner"></span>
+      </span>
+    </button>
+    <nav role="navigation" class="acc-nav" id="nav">
+      <ul class="usa-unstyled-list acc-nav-list">
         {% assign menu = site.contentful.menu | where: "name", "Header" | first %}
         {% for item in menu.items %}
           <li>
-            <a class="usa-nav-link acc-nav-link {{item.slug}}" href="{% url_for item %}">
-              <span>{{item.title}}</span>
-            </a>
+            <a class="acc-nav-link" href="{% url_for item %}"><span>{{item.title}}</span></a>
           </li>
         {% endfor %}
       </ul>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "babel-core": "^6.20.0",
     "dom-delegate": "^2.0.3",
     "element-closest": "^2.0.2",
+    "hamburgers": "^0.7.0",
     "photoswipe": "^4.1.1",
     "tether-tooltip": "^1.2.0",
     "uswds": "^0.13.1"


### PR DESCRIPTION
Replaces the USWDS navigation component with custom styles, a
flexbox-based header layout, and a drawer that slides vertically
below the header on small screens, rather than a full-height right-
hand sliding panel.

The new menu button uses a hamburger-to-close component from Jonathan
Suh's [hamburgers] library (installed via npm).

[hamburgers]: https://github.com/jonsuh/hamburgers