### PR TITLE
Rename menus with spaces, working around Jekyll where filter bug

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
         <div class="usa-width-one-third">
           <h4>Quick Links</h4>
           <ul class="usa-unstyled-list">
-            {% assign primary_footer = site.contentful.menu | where: "name", "PrimaryFooter" | first %}
+            {% assign primary_footer = site.contentful.menu | where_exp: "menu", "menu.name == 'Footer - Quick Links'" | first %}
             {% for item in primary_footer.items %}
               <li>
                 <a href="{% url_for item %}">
@@ -18,7 +18,7 @@
         <div class="usa-width-one-third">
           <h4>About Us</h4>
           <ul class="usa-unstyled-list">
-            {% assign about_links = site.contentful.menu | where: "name", "AboutFooter" | first %}
+            {% assign about_links = site.contentful.menu | where_exp: "menu", "menu.name == 'Footer - About Us'" | first %}
             {% for item in about_links.items %}
             <li>
               <a href="{% url_for item %}">

--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@ layout: default
       <h2>Welcome message that helps introduce the options that are shown below.</h2>
     </header>
 
-    {% assign tiles = site.contentful.menu | where: "name", "HomepageTiles" | first %}
+    {% assign links = site.contentful.menu | where_exp: "menu", "menu.name == 'Homepage'" | first %}
     <div class="acc-button-grid-wide">
-      {% for tile in tiles.items %}
-        <a href="{% url_for tile %}" class="acc-button acc-button-primary">
-          <h3>{{ tile.title }}</h3>
+      {% for link in links.items %}
+        <a href="{% url_for link %}" class="acc-button acc-button-primary">
+          <h3>{{ link.title }}</h3>
           {% if doc.description %}
             <div class="acc-button-description">
               {{ doc.description | markdownify }}


### PR DESCRIPTION
Jekyll's Liquid where filter has an odd bug that prevents it from
correctly matching values with spaces in the name, so this switches
to where_exp so that we can have values with spaces.