### PR TITLE
Support option to render gallery as full-width images

### DIFF
--- a/_assets/javascripts/photoswipe.js
+++ b/_assets/javascripts/photoswipe.js
@@ -96,7 +96,7 @@
   }
 
   function initPhotoSwipeFromDOM() {
-    var galleryElements = document.querySelectorAll(".acc-gallery");
+    var galleryElements = document.querySelectorAll(".acc-gallery-thumbnails");
 
     Array.prototype.forEach.call(galleryElements, function (gallery, i) {
       gallery.addEventListener("click", handleThumbnailClick);

--- a/_assets/stylesheets/components/gallery.scss
+++ b/_assets/stylesheets/components/gallery.scss
@@ -5,10 +5,15 @@
 }
 
 .acc-gallery-photo {
-  width: calc((100% - 0.5em)/2); // 0.5em gutter
+  flex-basis: calc((100% - 0.5em)/2); // 0.5em gutter
   margin: 0;
   margin-right: 0.5em;
   margin-bottom: 0.5em;
+}
+
+.acc-gallery:not(.acc-gallery-thumbnails) .acc-gallery-photo {
+  flex-grow: 1;
+  flex-shrink: 0;
 }
 
 .acc-gallery-photo:nth-of-type(2n) {
@@ -17,7 +22,7 @@
 
 @media screen and (min-width: $medium-screen) {
   .acc-gallery-photo {
-    width: calc((100% - 1em)/3); // 0.5em gutter x 2
+    flex-basis: calc((100% - 1em)/3); // 0.5em gutter x 2
   }
 
   .acc-gallery-photo:nth-of-type(2n) {

--- a/_includes/components/content_blocks/gallery.html
+++ b/_includes/components/content_blocks/gallery.html
@@ -2,17 +2,23 @@
 
 {% if block.title %}<h3 class="acc-content-block-header">{{ block.title }}</h3>{% endif %}
 
-<div itemscope itemtype="http://schema.org/ImageGallery" data-gid="{{ block.sys.id }}" class="acc-gallery">
+<div itemscope itemtype="http://schema.org/ImageGallery" data-gid="{{ block.sys.id }}" class="acc-gallery {% unless block.showThumbnails == false %}acc-gallery-thumbnails{% endunless %}">
   {% for image in block.images %}
     {% if image.url %}
       <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject" data-index="{{ forloop.index0 }}" data-pid="{{ image.sys.id }}" class="acc-gallery-photo">
-        <a href="{{ image.url }}?w=1800" itemprop="contentUrl" data-width="{{ image.width }}" data-height="{{ image.height }}" data-url="{{ image.url }}">
-          <img src="{{ image.url }}?w=330&h=220&fit=thumb"
-            srcset="{{ image.url }}?w=990&h=660&fit=thumb 3x,
-                    {{ image.url }}?w=660&h=440&fit=thumb 2x,
-                    {{ image.url }}?w=330&h=220&fit=thumb"
-            itemprop="thumbnail" alt="{{ image.title }}" />
-        </a>
+        {% if block.showThumbnails == false %}
+          <img src="{{ image.url }}?w=960"
+            srcset="{{ image.url }}?w=1920 2x,
+                    {{ image.url }}?w=960" alt="{{ image.title }}" />
+        {% else %}
+          <a href="{{ image.url }}?w=1800" itemprop="contentUrl" data-width="{{ image.width }}" data-height="{{ image.height }}" data-url="{{ image.url }}">
+            <img src="{{ image.url }}?w=330&h=220&fit=thumb"
+              srcset="{{ image.url }}?w=990&h=660&fit=thumb 3x,
+                      {{ image.url }}?w=660&h=440&fit=thumb 2x,
+                      {{ image.url }}?w=330&h=220&fit=thumb"
+              itemprop="thumbnail" alt="{{ image.title }}" />
+          </a>
+        {% endif %}
         {% if image.description %}
           <figcaption class="sr-only" itemprop="caption description">{{ image.description }}</figcaption>
         {% endif %}


### PR DESCRIPTION
Instead of thumbnails that open an image viewer. This lets content
editors use gallery blocks when they only need to add one or two
images to a page, which is preferable to using a text block because
it means the asset can be replaced in Contentful without needing to
also edit the text blocks that reference it.