### PR TITLE
Add Contact Sales form to the Book an Event page template

### DIFF
--- a/_assets/stylesheets/elements/buttons.scss
+++ b/_assets/stylesheets/elements/buttons.scss
@@ -76,7 +76,9 @@
   }
 }
 
-.acc-button-tertiary, .acc-button-tertiary:hover {
+.acc-button-tertiary,
+.acc-button-tertiary:hover,
+.acc-button-tertiary:active {
   background-color: $acc-color-primary-light;
   color: $acc-color-gray-dark;
   display: inline-block;

--- a/_assets/stylesheets/elements/forms.scss
+++ b/_assets/stylesheets/elements/forms.scss
@@ -1,0 +1,16 @@
+.acc-form {
+  margin-top: 6rem;
+
+  legend h3 {
+    margin-top: 0;
+  }
+}
+
+.acc-form .acc-button[type="submit"] {
+  display: block;
+  width: 100%;
+
+  @media screen and (min-width: $medium-screen) {
+    width: auto;
+  }
+}

--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -10,6 +10,7 @@
 
 @import "elements/reset";
 @import "elements/mixins";
+@import "elements/forms";
 @import "elements/tables";
 @import "elements/typography";
 @import "elements/buttons";

--- a/_assets/stylesheets/variables/uswds.scss
+++ b/_assets/stylesheets/variables/uswds.scss
@@ -28,9 +28,9 @@ $font-normal: 400;
 $font-bold: 700;
 
 // Color
-$color-primary: #0071bc;
-$color-primary-darker: #205493;
-$color-primary-darkest: #112e51;
+$color-primary: $acc-color-primary;
+$color-primary-darker: $acc-color-primary-dark;
+$color-primary-darkest: $acc-color-primary-dark;
 
 $color-primary-alt: #02bfe7;
 $color-primary-alt-dark: #00a6d2;
@@ -48,12 +48,12 @@ $color-white: #ffffff;
 $color-base: $acc-color-gray;
 $color-black: #000000;
 
-$color-gray-dark: #323a45;
-$color-gray: #5b616b; // lighten($color-gray-dark, 20%)
+$color-gray-dark: $acc-color-gray-dark;
+$color-gray: $acc-color-gray; // lighten($color-gray-dark, 20%)
 $color-gray-medium: #757575; // lightest gray that passes color contrast
-$color-gray-light: #aeb0b5; // lighten($color-gray-dark, 60%)
+$color-gray-light: $acc-color-gray-light; // lighten($color-gray-dark, 60%)
 $color-gray-lighter: #d6d7d9; // lighten($color-gray-dark, 80%)
-$color-gray-lightest: #f1f1f1; // lighten($color-gray-dark, 91%)
+$color-gray-lightest: $acc-color-gray-lightest; // lighten($color-gray-dark, 91%)
 
 $color-gray-warm-dark: #494440;
 $color-gray-warm-light: #e4e2e0; // lighten($color-gray-warm-dark, 90%)

--- a/_assets/stylesheets/vendor/uswds.scss
+++ b/_assets/stylesheets/vendor/uswds.scss
@@ -1,2 +1,6 @@
+//= link_tree ../../../node_modules/uswds/src/img
+
+$image-path: "uswds/src/img";
+
 @import "variables/all";
 @import "uswds/src/stylesheets/all";

--- a/_config/acc.yml
+++ b/_config/acc.yml
@@ -13,6 +13,9 @@ google_analytics_id: UA-87703455-1
 facebook_url: http://www.facebook.com/AustinConventionCenter/
 instagram_url: http://www.instagram.com/accdtx/
 
+contact_sales_form:
+  formspree_email: ConventionSales@austintexas.gov
+
 # Build settings
 destination: _site/acc
 assets:

--- a/_config/pec.yml
+++ b/_config/pec.yml
@@ -13,6 +13,9 @@ google_analytics_id: TBD
 facebook_url: https://www.facebook.com/PalmerEventsCenter/
 instagram_url: https://www.instagram.com/pectx/
 
+contact_sales_form:
+  formspree_email: PalmerSales@austintexas.gov
+
 # Build settings
 destination: _site/pec
 assets:

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -10,6 +10,7 @@ layout: default
   </div>
   <div class="usa-width-two-thirds">
     {% include components/content_blocks.html blocks=page.contentful.contentBlocks %}
+    {{ content }}
   </div>
   {% include sidebar.html %}
 </div>

--- a/_templates/book-an-event.html
+++ b/_templates/book-an-event.html
@@ -12,6 +12,9 @@ layout: page
     <label for="email" class="usa-input-required">Your email</label>
     <input id="email" name="_replyto" type="email" required="" aria-required="true" placeholder="first.last@example.com">
 
+    <label for="phone" class="usa-input-required">Your phone</label>
+    <input id="email" name="phone" type="text" required="" aria-required="true" placeholder="(512) 555-1234">
+
     <label for="organization">Organization name</label>
     <input id="organization" name="organization" type="text">
 
@@ -27,16 +30,11 @@ layout: page
     <input id="dates-flexible" type="checkbox" name="dates-flexible" value="dates-flexible">
     <label for="dates-flexible">These dates are flexible.</label>
 
-    <label for="options">Budget</label>
-    <select name="options" id="options">
-      <option value="Less than $10,000">Less than $10,000</option>
-      <option value="$10,000 to $25,000">$10,000 to $25,000</option>
-      <option value="$25,000 to $100,000">$25,000 to $100,000</option>
-      <option value="More than $100,000">More than $100,000</option>
-    </select>
+    <label for="budget">Total Budget</label>
+    <input id="budget" name="budget" type="text">
 
     <label for="additional-information">Additional information</label>
-    <textarea id="additional-information" name="additional-information"></textarea>
+    <textarea id="additional-information" name="additional-information" placeholder="Space requirements, food and beverage needs, etc..."></textarea>
 
     <input type="hidden" name="_next" value="{{ "/thank-you/" | absolute_url }}" />
     <input type="text" name="_gotcha" style="display:none" />

--- a/_templates/book-an-event.html
+++ b/_templates/book-an-event.html
@@ -1,0 +1,46 @@
+---
+layout: page
+---
+
+<form class="usa-form-large acc-form" action="https://formspree.io/{{ site.contact_sales_form.formspree_email }}" method="POST">
+  <fieldset>
+    <legend><h3>Contact Sales</h3></legend>
+
+    <label for="name" class="usa-input-required">Your name</label>
+    <input id="name" name="name" type="text" required="" aria-required="true" placeholder="First Last">
+
+    <label for="email" class="usa-input-required">Your email</label>
+    <input id="email" name="_replyto" type="email" required="" aria-required="true" placeholder="first.last@example.com">
+
+    <label for="organization">Organization name</label>
+    <input id="organization" name="organization" type="text">
+
+    <label for="event-name">Event name</label>
+    <input id="event-name" name="event-name" type="text">
+
+    <label for="start-date">Start date</label>
+    <input id="start-date" name="start-date" type="date" placeholder="mm/dd/yyyy">
+
+    <label for="end-date">End date</label>
+    <input id="end-date" name="end-date" type="date" placeholder="mm/dd/yyyy">
+
+    <input id="dates-flexible" type="checkbox" name="dates-flexible" value="dates-flexible">
+    <label for="dates-flexible">These dates are flexible.</label>
+
+    <label for="options">Budget</label>
+    <select name="options" id="options">
+      <option value="Less than $10,000">Less than $10,000</option>
+      <option value="$10,000 to $25,000">$10,000 to $25,000</option>
+      <option value="$25,000 to $100,000">$25,000 to $100,000</option>
+      <option value="More than $100,000">More than $100,000</option>
+    </select>
+
+    <label for="additional-information">Additional information</label>
+    <textarea id="additional-information" name="additional-information"></textarea>
+
+    <input type="hidden" name="_next" value="{{ "/thank-you/" | absolute_url }}" />
+    <input type="text" name="_gotcha" style="display:none" />
+
+    <input type="submit" value="Submit" class="usa-button-unstyled acc-button acc-button-tertiary" />
+  </fieldset>
+</form>


### PR DESCRIPTION
* Uses and mostly doesn't modify the USWDS form styles. Implements
  semantic types (email, date) and attributes (required) to maximize
  browser-specific form features (like Chrome's validation and date
  picker).

* The form is relayed to email via FormSpree, to an email address
  specificied in the site-specific YAML config files. The main caveat
  with FormSpree is that it requires confirming the domain/email pair
  each time either changes, e.g. separately on the beta and www
  subdomains and separately for ACC and PEC.

* FormSpree redirects to the URL specified in the hidden input named
  next, which is currently set to "/thank-you/", so that page must be
  created and maintained in Contentful.