### PR TITLE
Create basic print stylesheet

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,7 +5,7 @@ permalink: 404.html
 
 <div class="usa-grid">
   <div class="usa-width-one-whole">
-    <header>
+    <header class="acc-content-header">
       <h1>404</h1>
     </header>
     <h2>Sorry, the page you were looking for has moved or doesn’t exist anymore.</h2>

--- a/_assets/stylesheets/components/calendar.scss
+++ b/_assets/stylesheets/components/calendar.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   overflow: hidden;
 
-  @media screen and (min-width: $small-screen) {
+  @media all and (min-width: $small-screen) {
     flex-direction: row;
     min-height: 19rem;
   }
@@ -51,7 +51,7 @@
     margin: 0;
   }
 
-  @media screen and (min-width: $small-screen) {
+  @media all and (min-width: $small-screen) {
     width: 18rem;
   }
 }

--- a/_assets/stylesheets/print.scss
+++ b/_assets/stylesheets/print.scss
@@ -1,0 +1,71 @@
+@import "variables/all";
+
+body > *:not(#main-content) {
+  display: none;
+}
+
+#main-content::before {
+  content: "Please consider the environment when printing (try saving to PDF instead!)";
+}
+
+.acc-content-header h1 {
+  font-size: $h2-font-size;
+
+  &::before {
+    $title: config_value("title");
+    content: "#{$title}: ";
+  }
+}
+
+.usa-grid {
+  padding: 0;
+}
+
+.acc-content-block {
+  p {
+    max-width: none !important;
+  }
+}
+
+.acc-content-block ul,
+.acc-accordion-content ul {
+  max-width: none !important;
+}
+
+.usa-accordion li {
+  background: transparent;
+}
+
+.acc-accordion-button {
+  background: transparent;
+  font-size: $h3-font-size;
+  margin: 1em auto;
+  padding: 0;
+  pointer-events: none;
+
+  &::after {
+    content: "" !important;
+  }
+}
+
+.acc-accordion-content {
+  display: block !important;
+  padding: 0;
+}
+
+.acc-button,
+.acc-calendar-event,
+.acc-calendar-event-date {
+  background: transparent !important;
+  page-break-inside: avoid;
+}
+
+.acc-calendar-event-date {
+  h1, h4 {
+    color: $acc-color-gray-dark;
+  }
+}
+
+.acc-sidenav {
+  box-shadow: none;
+}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,6 +21,7 @@
   <link rel="canonical" href="{{ site.url }}{{ page.url }}" />
 <!-- Styles -->
   {% stylesheet main %}
+  {% stylesheet print media:"print" %}
 <!-- Google Analytics -->
   {% include analytics/google_analytics.html %}
 </head>

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="usa-grid">
   <div class="usa-width-one-whole">
-    <header>
+    <header class="acc-content-header">
       <h1>Calendar</h1>
     </header>
   </div>

--- a/_layouts/floor_plan.html
+++ b/_layouts/floor_plan.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="usa-grid acc-floor-plan">
   <div class="usa-width-one-whole">
-    <header>
+    <header class="acc-content-header">
       <h1>Floor Plans</h1>
     </header>
   </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="usa-grid">
   <div class="usa-width-one-whole">
-    <header>
+    <header class="acc-content-header">
       <h1>{{ page.contentful.title }}</h1>
     </header>
   </div>

--- a/_layouts/section.html
+++ b/_layouts/section.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="usa-grid">
   <div class="usa-width-one-whole">
-    <header>
+    <header class="acc-content-header">
       <h1>{{ page.contentful.title }}</h1>
     </header>
   </div>

--- a/_templates/press-releases.html
+++ b/_templates/press-releases.html
@@ -5,7 +5,7 @@ contentful_id: 4S1U5bQghaQAaKQsqOKywe
 
 <div class="usa-grid">
   <div class="usa-width-one-whole">
-    <header>
+    <header class="acc-content-header">
       <h1>{{ page.contentful.title }}</h1>
     </header>
   </div>


### PR DESCRIPTION
* Hides all content not in #main-content
* Displays all accordion content and optimizes "accordion button"
  styles
* Improves calendar rendering in print
* Adds a "Please consider the environment" note to the top of the
  first printed page
* Adds a "acc-content-header" class to the header tags containing the
  page title, so that it can be targeted and prefixed with the site
  title in print.