### PR TITLE
Add a simple rake task to trigger nightly site rebuilds via Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby "2.3.1"
 
 gem "activesupport"
 gem "autoprefixer-rails"
+gem "faraday"
 gem "font-awesome-sass"
 gem "jekyll"
 gem "jekyll-assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,8 @@ GEM
     execjs (2.7.0)
     extras (0.1.0)
       forwardable-extended (~> 2.5)
+    faraday (0.10.1)
+      multipart-post (>= 1.2, < 3)
     fastimage (2.0.0)
       addressable (~> 2)
     ffi (1.9.14)
@@ -135,6 +137,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   autoprefixer-rails
+  faraday
   font-awesome-sass
   foreman
   jekyll

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project implements a decoupled CMS, which you can read about in [our Medium
 
 The same source builds both austinconventioncenter.com and palmereventscenter.com using content from separate Contentful spaces. Site-specific files in [_config/](_config) extend the base configuration found in [_config.yml](_config.yml).
 
-We continuously deploy the static sites to Amazon S3 by using [s3_website][] on CircleCI. The [Rakefile](Rakefile) includes CI-specific build and deploy commands.
+We continuously deploy the static sites to Amazon S3 by using [s3_website][] on CircleCI. The [Rakefile](Rakefile) includes CI-specific build and deploy commands. We also use Heroku Scheduler to trigger nightly CI builds that ensure imported calendar events are kept current.
 
 [medium]: https://medium.com/city-of-austin-design-technology-innovation/how-were-thinking-about-content-management-for-city-government-88f563497096
 [contentful]: https://www.contentful.com

--- a/Rakefile
+++ b/Rakefile
@@ -95,4 +95,20 @@ namespace :ci do
     task = ENV["SITE"] ? "deploy:#{ENV["SITE"]}" : "deploy"
     Rake::Task[task].invoke
   end
+
+  # Nightly task run by Heroku Scheduler to rebuild the site (rebuilding nightly ensures the
+  # calendar is always up-to-date).
+  task :scheduler do
+    require 'faraday'
+
+    connection = Faraday.new("https://circleci.com") do |faraday|
+      faraday.request  :url_encoded
+      faraday.response :logger
+      faraday.adapter Faraday.default_adapter
+    end
+
+    connection.post("/api/v1/project/cityofaustin/austinconventioncenter.com/tree/master") do |request|
+      request.params["circle-token"] = ENV["CIRCLE_TOKEN"]
+    end
+  end
 end


### PR DESCRIPTION
Intended as the simplest possible way to trigger a rebuild of the
both sites each night, which needs to happen to ensure the Calendar
stays up-to-date even if updates aren't made via GitHub or Contentful
in the current month.

It's obviously a somewhat naive solution, but the risks of failure
are fairly low, and low-cost even if they do happen. As the City
invests resources in building out more static-site infrastructure,
it's possible (even probable) that this will be replaced by something
a little more robust (e.g. with error handling, and perhaps using
Lambda w/ Cloudwatch events instead of Heroku Scheduler).