### PR TITLE
ACC Assess

### DIFF
--- a/_assets/stylesheets/components/footer.scss
+++ b/_assets/stylesheets/components/footer.scss
@@ -102,4 +102,15 @@
 
 .acc-footer-copyright {
   font-size: 1.3rem;
+
+}
+
+
+.acc-test {
+  background-color: #ffffff;
+}
+
+.acc-test span {
+  padding-left: 10px;
+  padding-right: 10px;
 }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -81,3 +81,8 @@
     </div>
   </div>
 </footer>
+<div class="acc-test">
+  {% for breadcrumb in page.breadcrumbs %}
+    <span >{{ breadcrumb.title }}</span>
+  {% endfor %}
+</div>


### PR DESCRIPTION
Add debug code below the </footer> tag to show the
page's Title and Section information coming from contentful.

Use the breadcrumb information to display these items, and add
minor styling.

Forked repository, created a branch "accd_assess", will commit this
change and make a pull request for Matt.