### PR TITLE
Add Facebook campaign analytics

### DIFF
--- a/_config/pec.yml
+++ b/_config/pec.yml
@@ -10,6 +10,7 @@ footer_address:
   phone: (512) 404-4500
 
 google_analytics_id: UA-87703455-3
+facebook_analytics_pixel_id: 1623289217737073
 facebook_url: https://www.facebook.com/PalmerEventsCenter/
 instagram_url: https://www.instagram.com/pectx/
 youtube_url: https://www.youtube.com/channel/UCUfiBJZM1W58J2uTIssujKQ

--- a/_includes/analytics/facebook_analytics.html
+++ b/_includes/analytics/facebook_analytics.html
@@ -1,0 +1,24 @@
+<!-- Facebook Pixel Code -->
+<script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '{{ site.facebook_analytics_pixel_id }}');
+  fbq('track', 'PageView');
+  {% if page.title == 'Book an Event' %}
+    fbq('track', 'Lead');
+  {% endif %}
+</script>
+<noscript>
+  <img height="1" width="1" src="https://www.facebook.com/tr?id={{ site.facebook_analytics_pixel_id }}&ev=PageView&noscript=1"/>
+</noscript>
+{% if page.title == 'Book an Event' %}
+  <noscript>
+    <img height="1" width="1" src="https://www.facebook.com/tr?id={{ site.facebook_analytics_pixel_id }}&ev=Lead&noscript=1"/>
+  </noscript>
+{% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,4 +24,8 @@
   {% stylesheet print media:"print" %}
 <!-- Google Analytics -->
   {% include analytics/google_analytics.html %}
+<!-- Facebook Analytics -->
+  {% if site.facebook_analytics_pixel_id %}
+    {% include analytics/facebook_analytics.html %}
+  {% endif %}
 </head>


### PR DESCRIPTION
This includes 2 levels of FB campaign tracking - a page view and what I believe is a paid campaign referral tracking that is isolated to the "Book an Event" page. I was not able to confirm the efficacy of the tracking snippet due to lack of access to the associated FB ads campaign. I am assuming that I can daisy-chain the `PageView` and `Lead` functions within a single `<script>` tag but without access to the campaign itself I cannot confirm this.