### PR TITLE
Configuration change per contentful to allow fetching items over the …

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ exclude:
 
 contentful_options: &contentful_options
   cda_query:
+    include: 2
     limit: 1000
   all_entries: true
   content_types:


### PR DESCRIPTION
This issue started when a content editor removed the 2016 Awards Ceremony video link and added the 2017 link. The link appeared on Staging, but it would never appear on production. After contacting Contentful support, their engineer analyzed the situation and gave this explanation:

> So as I mentioned previously, the problem arises from the behavior of the "includes" attribute in the entries result that comes back from Contentful. By default, Contentful includes one layer deep of linked content entries in the includes parameters.
> 
> In your case, you have an entry "Press Room & Video", which links to "Test Menu". However the problematic link (for "2017 ACCD Employee Awards Video") is linked to "Test Menu". So in the set of results we return on the first page, we don't end up including "2017 ACCD Employee Awards Video" in the "includes" attribute; only "Test Menu."
> 
> The fix for now to change the query parameter to "include: 2" will then ensure that "2017 ACCD Employee Awards Video" is included in the initial query results.

This change adds that setting to the configuration file.