### PR TITLE
fix links for calendar

### DIFF
--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -37,7 +37,19 @@ layout: default
         <ul class="usa-unstyled-list">
           {% for event in events %}
             <li>
-              <a href="{% if event.website %}http://{{event.website}}{% else %}#{% endif %}" class="acc-calendar-event{% if event.website %} acc-calendar-event-link{% endif %}">
+
+              <a href="{% if event.website %}
+                         {% if event.website contains 'http' or event.website contains 'https' %}
+                           {{ event.website }}
+                         {% else %}
+                           {{ event.website | prepend: 'http://' }}
+                         {% endif %}
+                       {% else %}
+                         #
+                       {% endif %}"
+                 class="acc-calendar-event{% if event.website %} acc-calendar-event-link{% endif %}">
+
+
                 {% assign arrive_month = event.arrive_date | date: "%B" %}
                 {% assign depart_month = event.depart_date | date: "%B" %}
 


### PR DESCRIPTION
Some calendar links work and others are broken. This is because "http://" is being prepended to all links, but in the data, some links already have the "http://" or "https://" included.

This change checks the event.website to determine if http or https is included and 
only adds it when it is missing (as required for our application to recognize that is is 
a full URL and not a relative one). 

In the 2018 calendar and production, the following links on production are broken:
2018 American Meterological Society
2018 SXSW Volunteer Call
2018 Virtual Reality Show
2018 Build Expo
2018 Dell Children's Gala
2018 SXSW Volunteer call
2018 TASA Midwinter Conference


The fix for this is already deployed on staging and can be tested on those pages there. 

As an additional note, the last link (TASA Midwinter Conference) redirects to a 
"Sorry, the page is inactive or protected." message, so the link my need to be
checked. 

