### PR TITLE
compensate for renaming of 'Photos & Tours' page, center captions in …

### DIFF
--- a/_assets/stylesheets/components/carousel.scss
+++ b/_assets/stylesheets/components/carousel.scss
@@ -69,7 +69,7 @@
 
 
 
-
+.pswp__caption__center {text-align: center !important;}
 
 @media screen  and (min-width: 951px)  {
   .jcarousel-control-prev,

--- a/_includes/components/content_blocks.html
+++ b/_includes/components/content_blocks.html
@@ -9,7 +9,7 @@
             {% include components/content_blocks/contact.html block=block %}
           {% when "galleryBlock" %}
             {% assign photoswipe = true %}
-            {% if page.title == "Tour & Photos" %}
+            {% if page.title == "Photos & Virtual Tour" %}
               {% include components/content_blocks/carousel.html block=block %}
             {% else %}
               {% include components/content_blocks/gallery.html block=block %}


### PR DESCRIPTION
…pop-up images

Yesterday a page was renamed to "Photos & Virtual Tour" 
from "Tour & Photos". 

The carousel code is keying on the page name to show the 
Gallery Block differently on the page (as a carousel). 

FYI: There are a few pages in the site where page titles are
used in code conditionals. So if those page titles change it 
will require a code change to keep the same behavior
(like the Gallery images being displayed as a carousel instead
of just showing images). 

"Book and Event"
"Floor Plans"
"Tour & Photos"