### PR TITLE
change  'The Facility' to 'Photos'

### DIFF
--- a/_includes/components/content_blocks/carousel.html
+++ b/_includes/components/content_blocks/carousel.html
@@ -5,7 +5,7 @@
 <script src="https://code.jquery.com/jquery-1.8.2.min.js" type="text/javascript"></script>
 {% if block.title == "Facility Photos" %}
 
-  <h3 class="acc-content-block-header" style="margin-top: 1.5em;">The Facility</h3>
+  <h3 class="acc-content-block-header" style="margin-top: 1.5em;">Photos</h3>
   <div class="wrapper"  id="carousel_{{ block.sys.id }}">
     <div class="jcarousel-wrapper">
         <div class="jcarousel">


### PR DESCRIPTION
Change the heading on the ACC  Photos page to say "Photos" instead of "The Facility"