### PR TITLE
change  'The Facility' to 'Photos' and allow pop-up arrow navigation …

### DIFF
--- a/_includes/components/content_blocks/carousel.html
+++ b/_includes/components/content_blocks/carousel.html
@@ -5,40 +5,30 @@
 <script src="https://code.jquery.com/jquery-1.8.2.min.js" type="text/javascript"></script>
 {% if block.title == "Facility Photos" %}
 
-  <h3 class="acc-content-block-header" style="margin-top: 1.5em;">The Facility</h3>
+  <h3 class="acc-content-block-header" style="margin-top: 1.5em;">Photos</h3>
   <div class="wrapper"  id="carousel_{{ block.sys.id }}">
     <div class="jcarousel-wrapper">
         <div class="jcarousel">
 
-            <ul style="display:flex;">
+            <ul itemscope itemtype="http://schema.org/ImageGallery" data-gid="{{ block.sys.id }}" class="acc-gallery {% unless block.showThumbnails == false %}acc-gallery-thumbnails{% endunless %}" style="display:flex;">
                 {% for gallery_image in block.galleryImages limit:9 %}
                   {% assign image = gallery_image.image %}
 
                   {% if image.url %}
                     <li class="carousel-li">
-                      <div itemscope itemtype="http://schema.org/ImageGallery" data-gid="{{ block.sys.id }}" class="acc-gallery  acc-gallery-thumbnails">
-
                         <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject" data-index="{{ forloop.index0 }}" data-pid="{{ image.sys.id }}" class="acc-gallery-photo acc-gallery-photo-carousel" style="width: 99%;padding-left:3px;padding-right: 3px;">
-                            
-
                           <a href="{{ image.url }}?w=1800" itemprop="contentUrl" data-width="{{ image.width }}" data-height="{{ image.height }}" data-url="{{ image.url }}" class="carousel-image-link">
                               <img src="{{ image.url }}?w=1920"
                                    srcset="{{ image.url }}?w=1920 2x,
                                    {{ image.url }}?w=960" alt="{{ gallery_image.title | default: image.title }}" />
                           </a>
 
-
-
                           {% if block.showCaptions or gallery_image.caption != empty %}
                             <figcaption class="acc-gallery-caption caption-container" itemprop="caption description">{{ gallery_image.caption | default: gallery_image.title | markdownify }}</figcaption>
                           {% endif %}
-
                         </figure>
-                      </div>
                     </li>
-
                   {% endif %}
-
                 {% endfor %}
             </ul>
             <p class="jcarousel-pagination" style="width: 100%;text-align:center;"></p>


### PR DESCRIPTION
…to work

This answers Noe's question about the missing arrows when you mouse-click on an image in the carousel and the image pops up in the viewer. Previously a single image appeared when the window opened and the arrows to navigate through the pop-up were missing. 

These changes are already deployed on staging for review. 