### PR TITLE
Rename "Calendar" as "Events"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,10 +79,10 @@ defaults:
       layout: "page"
       permalink: "/:slug/"
   - scope:
-      type: calendar
+      type: events
     values:
-      layout: calendar
-      permalink: "/calendar/:year/:month/"
+      layout: events
+      permalink: "/events/:year/:month/"
   -
     scope:
       type: press-room

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -5,16 +5,16 @@ layout: default
 <div class="usa-grid">
   <div class="usa-width-one-whole">
     <header class="acc-content-header">
-      <h1>Calendar</h1>
+      <h1>Events</h1>
     </header>
   </div>
-  {% if site.calendar and site.calendar != empty %}
+  {% if site.events and site.events != empty %}
     <aside class="usa-width-one-fourth">
       <nav role="navigation" class="acc-sidenav" id="sidenav">
         <button class="usa-button-unstyled acc-sidenav-close">
           <img src="{% asset_path uswds/src/img/close.svg %}" alt="close">
         </button>
-        {% assign years = site.calendar | group_by: "year" %}
+        {% assign years = site.events | group_by: "year" %}
         {% for year in years %}
           <h4>{{ year.name }}</h4>
           <ul class="usa-unstyled-list acc-sidenav-list">
@@ -83,8 +83,8 @@ layout: default
           {% endfor %}
         </ul>
       {% else %}
-        {% comment %} Redirect /calendar/ to current month {% endcomment %}
-        {% assign current_month = site.calendar | first %}
+        {% comment %} Redirect /events/ to current month {% endcomment %}
+        {% assign current_month = site.events | first %}
         <script type="text/javascript">
           window.location = "{{ current_month.url }}";
         </script>

--- a/_plugins/generators/calendar.rb
+++ b/_plugins/generators/calendar.rb
@@ -10,8 +10,8 @@ module Jekyll
     DATE_KEYS = %w(arrive depart).freeze
 
     def generate(site)
-      section = site.collections["calendar"]
-      events = site.data.dig("socrata", "calendar", "events")
+      section = site.collections["events"]
+      events = site.data.dig("socrata", "events", "events")
 
       return if section.nil? || events.nil?
 
@@ -70,5 +70,3 @@ module Jekyll
 
   end
 end
-
-

--- a/_templates/calendar.html
+++ b/_templates/calendar.html
@@ -1,3 +1,0 @@
----
-layout: calendar
----

--- a/_templates/events.html
+++ b/_templates/events.html
@@ -1,0 +1,3 @@
+---
+layout: events
+---

--- a/lib/calendar/import.rb
+++ b/lib/calendar/import.rb
@@ -8,7 +8,7 @@ module Calendar
     class << self
       def import(config)
         results = socrata_client.get("e43u-d7ev", "$limit": 5000)
-        path = File.join(config["source"], config["data_dir"], "socrata", "calendar", "events.yaml")
+        path = File.join(config["source"], config["data_dir"], "socrata", "events", "events.yaml")
 
         FileUtils.mkdir_p(File.dirname(path))
 


### PR DESCRIPTION
The primary goal was for the "Calendar" page/section to be renamed "Events" on the user-facing parts of the site. The change could have been isolated more than it is here, only making the substitution where the calendar builder is looking for the "Events" content item from Contentful, but then we would have been left with routes that say "/calendar" for a top-level page titled "Events", and the code that supports this feature would have been semantically inconsistent, and therefore confusing. This resulted in my decision to replace all references to "Calendar". The one place this gets weird is in the nesting of individual "events" under the "events" parent list (instead of "events" being children under "calendar" but) but I felt like that was a more reasonable approach than turning "events" into "calendar" at some point in the import/build chain.

Since these code changes are tied to Contentful changes this code must be coordinated with the publishing of the changes to the "Events" Page and Section in Contentful.