### PR TITLE
Add disclaimer to events page

### DIFF
--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -8,6 +8,14 @@ layout: default
       <h1>Events</h1>
     </header>
   </div>
+  {% if site.title == 'Austin Convention Center' %}
+    {% assign booking_adjective = 'contracted' %}
+  {% else %}
+    {% assign booking_adjective = 'booked' %}
+  {% endif %}
+  <p>
+    Please note the calendar of events below does not reflect all {{ booking_adjective }} dates. <a href="{{ site.url }}/planners/book-an-event/">Connect with our sales team</a> for date availability and event details.
+  </p>
   {% if site.events and site.events != empty %}
     <aside class="usa-width-one-fourth">
       <nav role="navigation" class="acc-sidenav" id="sidenav">


### PR DESCRIPTION
I initially tried doing this via Contentful, but ran into complexity in the site build process since all of the events/calendar pages are currently generated purely with Socrata data. To add a relationship between the contentful data and the events page within the build process seemed like far more effort than it was worth to make a couple pieces of static text that are not likely to change more than 2x/year editable via Contentful.

[Trello card](https://trello.com/c/8E0tlccS/323-include-disclaimer-verbiage-above-the-events-calendar-on-staging)