### PR TITLE
Increase min height of Virtual Tour iFrame

### DIFF
--- a/_includes/components/content_blocks/carousel.html
+++ b/_includes/components/content_blocks/carousel.html
@@ -45,9 +45,9 @@
       <h3 class="acc-content-block-header" style="margin-left: -20px;padding-bottom: 8px;">Virtual Tour</h3>
       <div>
           {% if site.title == "Palmer Events Center" %}
-            <iframe src="https://accd360tours.com/pec/index.html" style="width:100%;min-height:400px;"></iframe>
+            <iframe src="https://accd360tours.com/pec/index.html" style="width:100%;min-height:450px;"></iframe>
           {% elsif site.title == "Austin Convention Center" %}
-            <iframe src="https://accd360tours.com/accd/index.html" style="width:100%;min-height:400px;"></iframe>
+            <iframe src="https://accd360tours.com/accd/index.html" style="width:100%;min-height:450px;"></iframe>
           {% endif %}
 
       </div>


### PR DESCRIPTION
Some of the controls in the floor plans/overview info popup were getting cut off at the top.