### PR TITLE
Change value of ACC "Calendar Location" site variable

### DIFF
--- a/_config/acc.yml
+++ b/_config/acc.yml
@@ -3,7 +3,7 @@ environment: production
 title: Austin Convention Center
 url: "https://www.austinconventioncenter.com"
 
-calendar_location: "Austin Convention Center" # Socrata event data location value
+calendar_location: "Austin Convention Center Events" # Socrata event data location value
 
 footer_address:
   street: 500 E. Cesar Chavez St.

--- a/_config/acc_staging.yml
+++ b/_config/acc_staging.yml
@@ -3,7 +3,7 @@ environment: staging
 title: Austin Convention Center
 url: "https://staging.austinconventioncenter.com"
 
-calendar_location: "Austin Convention Center" # Socrata event data location value
+calendar_location: "Austin Convention Center Events" # Socrata event data location value
 
 footer_address:
   street: 500 E. Cesar Chavez St.


### PR DESCRIPTION
Long-story short, improperly formatted data was introduced to Socrata causing the build process to fail for a number of days. This appears to have been caused by Terri delivering an events spreadsheet to Chris that had "Austin Convention Center Events" instead of "Austin Convention Center" in the Location column for ACC events.