### PR TITLE
Track clicks on RFP external link clicks

### DIFF
--- a/_assets/javascripts/click_tracking.js
+++ b/_assets/javascripts/click_tracking.js
@@ -59,16 +59,11 @@ $(document).ready(function() {
   });
 
 /*
-  Form Submission
+  RFP Link
 */
-  // When a submit button is clicked
-  $('input[type=submit]').click(function() {
-    reportEvent('Form Submission', 'Submit Button Clicked', $(this).parents('form:first').attr('action'));
-  });
-
-  // When a form actually submits
-  $('form').submit(function() {
-    reportFormSubmisson(event);
+  // When the external RFP link is clicked
+  $('.acc-rfp-link').click(function() {
+    reportEvent('RFP External Link Click', $(this).text(), window.location.pathname);
   });
 
 /*


### PR DESCRIPTION
The decision was made to use Ungerboeck's white-label form creator to create temporary RFP forms until we have a native solution for website-to-USI RFP submission in place. Accordingly, the RFP text block in contentful has been updated to provide a link to the form instead of a solictation to email the sales team. This analytics change removes the old form submission tracking and replaces it with click tracking on the new RFP link, which is used on both the ACC and PEC sites.