### PR TITLE
Update Learn More links to handle new approach

### DIFF
--- a/_includes/components/content_blocks/learn_more_menu.html
+++ b/_includes/components/content_blocks/learn_more_menu.html
@@ -5,9 +5,11 @@
     {% for item in block.links %}
       <li class="acc-flex-thirds">
         {% if item.linkedItem %}
-        <a href="{{item.linkedItem.url}}" class="acc-learn-more-link">
+          {% assign doc = item.linkedItem | find_document %}
+          {% assign url = item.linkedItem.url | default: doc.url %}
+          <a href="{{url}}" class="acc-learn-more-link">
         {% else %}
-        <a href="/{{item.internalLink}}" class="acc-learn-more-link">
+          <a href="/{{item.internalLink}}" class="acc-learn-more-link">
         {% endif %}
           <img src="{{ item.photo.url }}?w=330&h=220&fit=thumb" alt="{{ item.photo.title }}" />
           <span class="acc-learn-more-link-title">


### PR DESCRIPTION
The bulk of the work here was on the Content Model side. This is an ugly workaround for the recursion issue created by how Contentful links references together. See https://github.com/contentful/jekyll-contentful-data-import/issues/67 and https://trello.com/c/N1NsvW0t/13-fix-broken-learn-more-handling-on-certain-page-menu-combinations for additional context.