### PR TITLE
Add disclaimer text to Events page

### DIFF
--- a/_config/pec.yml
+++ b/_config/pec.yml
@@ -10,7 +10,7 @@ footer_address:
   zip_code: 78704
   phone: (512) 404-4500
 
-google_analytics_id: UA-87703455-3
+google_analytics_id: UA-87703455-7
 facebook_analytics_pixel_id: 1623289217737073
 facebook_url: https://www.facebook.com/PalmerEventsCenter/
 instagram_url: https://www.instagram.com/pectx/

--- a/_config/pec_staging.yml
+++ b/_config/pec_staging.yml
@@ -10,7 +10,7 @@ footer_address:
   zip_code: 78704
   phone: (512) 404-4500
 
-google_analytics_id: UA-87703455-4
+google_analytics_id: UA-87703455-3
 facebook_analytics_pixel_id: 1623289217737073
 facebook_url: https://www.facebook.com/PalmerEventsCenter/
 instagram_url: https://www.instagram.com/pectx/

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -10,8 +10,10 @@ layout: default
     {% assign booking_adjective = 'booked' %}
     {% endif %}
     <p>
-      Please note the calendar of events below does not reflect all {{ booking_adjective }} dates. <a href="{{ site.url }}/request-a-proposal/">Connect
-        with our sales team</a> for date availability and event details.
+      For all inquiries regarding a specific event at the {{ site.title }}, please contact the event organizer. Clients who lease space at the {{ site.title }} plan, manage, and market their events. We are unable to answer event-related questions.
+    </p>
+    <p>
+      Please note the calendar of events below does not reflect all {{ booking_adjective }} dates. <a href="{{ site.url }}/request-a-proposal/">Connect with our sales team</a> for date availability and event details.
     </p>
   </header>
   <div class="acc-flex break-large">


### PR DESCRIPTION
This text is being added with the goal of reducing the number of event-specific inbound queries that come through via email and phone.