### PR TITLE
Add support for Contentful-driven press contact

### DIFF
--- a/_assets/stylesheets/elements/press_release.scss
+++ b/_assets/stylesheets/elements/press_release.scss
@@ -1,0 +1,10 @@
+.acc-press-release-contact {
+  text-align: right;
+  font-size: .8em;
+  margin-top: 2em;
+  p {
+    margin-top: 0;
+    text-align: right;
+  }
+}
+

--- a/_assets/stylesheets/elements/press_release.scss
+++ b/_assets/stylesheets/elements/press_release.scss
@@ -8,3 +8,9 @@
   }
 }
 
+.acc-press-release-list {
+  padding: 3rem;
+  li {
+    margin-bottom: 1em;
+  }
+}

--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -12,6 +12,7 @@
 @import "elements/buttons";
 @import "elements/lists";
 @import "elements/flex";
+@import "elements/press_release";
 @import "components/nav";
 @import "components/footer";
 @import "components/folders";

--- a/_layouts/press_release.html
+++ b/_layouts/press_release.html
@@ -10,5 +10,11 @@ layout: default
     <h4 class="acc-press-byline">{{ page.contentful.byline }}</h4>
     {{ page.contentful.date | date: "%B %-d, %Y" }}
     {{ page.contentful.content | markdownify }}
+    {% if page.contentful.contactInformation %}
+      <div class="acc-press-release-contact">
+        For more information contact:
+        {{ page.contentful.contactInformation | markdownify }}
+      </div>
+    {% endif %}
   </div>
 </div>

--- a/_layouts/press_release.html
+++ b/_layouts/press_release.html
@@ -5,6 +5,7 @@ layout: default
 <div class="acc-full">
   <div class="acc-two-thirds">
     <header>
+      <img src="{{ page.photo_url }}?w=900&h=410" />
       <h2>{{ page.contentful.title }}</h2>
     </header>
     <h4 class="acc-press-byline">{{ page.contentful.byline }}</h4>

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -37,6 +37,7 @@ module Jekyll
           page = generate_page(site, press_releases_section, attributes)
           page.data["breadcrumbs"][-1]["title"] = attributes["date"].strftime("%B %-d, %Y")
           page.data["photo_url"] = attributes["picture"]["url"] if attributes["picture"].present?
+          page.data["preview_text"] = attributes["previewText"] if attributes["previewText"].present?
         end
       end
     end

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -36,6 +36,7 @@ module Jekyll
           attributes["date"] = attributes["date"].utc # Undo implicit time zone conversion
           page = generate_page(site, press_releases_section, attributes)
           page.data["breadcrumbs"][-1]["title"] = attributes["date"].strftime("%B %-d, %Y")
+          page.data["photo_url"] = attributes["picture"]["url"] if attributes["picture"].present?
         end
       end
     end

--- a/_templates/press-room.html
+++ b/_templates/press-room.html
@@ -7,14 +7,33 @@ contentful_id: 4S1U5bQghaQAaKQsqOKywe
 <div class="acc-full">
   <div class="acc-flex no-break">
     <div class="acc-flex-two-thirds">
+      {%- assign press_releases = site.press-room | sort: "date" | reverse -%}
+      {%- for press_release in press_releases limit:3 -%}
+      <div class="acc-side-by-side-container">
+        <div class="acc-flex break-medium">
+          <div class="acc-flex-one-half">
+            <div class="acc-side-by-side-component">
+              <a href="{{ press_release.url }}">
+                <img src="{{ press_release.photo_url }}?w=900&h=410" />
+              </a>
+            </div>
+          </div>
+          <div class="acc-flex-one-half">
+            <div class="acc-side-by-side-component">
+              <strong>{{ press_release.date | date: "%B %-d, %Y" }}</strong>
+              <h3><a href="{{ press_release.url }}">{{ press_release.title }}</a></h3>
+            </div>
+          </div>
+        </div>
+      </div>
+      {%- endfor -%}
       <ul class="acc-unstyled-list acc-press-release-list">
-        {% assign press_releases = site.press-room | sort: "date" | reverse %}
-        {% for press_release in press_releases %}
-          <li>
-            <strong class="acc-press-release-date">{{ press_release.date | date: "%B %-d, %Y" }}</strong><br>
-            <a href="{{press_release.url}}">{{ press_release.title }}</a>
-          </li>
-        {% endfor %}
+        {%- for press_release in press_releases offset:3 -%}
+        <li>
+          <strong class="acc-press-release-date">{{ press_release.date | date: "%B %-d, %Y" }}</strong><br>
+          <a href="{{ press_release.url }}">{{ press_release.title }}</a>
+        </li>
+        {%- endfor -%}
       </ul>
     </div>
   </div>

--- a/_templates/press-room.html
+++ b/_templates/press-room.html
@@ -22,6 +22,12 @@ contentful_id: 4S1U5bQghaQAaKQsqOKywe
             <div class="acc-side-by-side-component">
               <strong>{{ press_release.date | date: "%B %-d, %Y" }}</strong>
               <h3><a href="{{ press_release.url }}">{{ press_release.title }}</a></h3>
+              {% if press_release.preview_text %}
+                {{ press_release.preview_text }}
+              {% endif %}
+              <p>
+                <a href="{{press_release.url}}" class="acc-button">Read More</a>
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This provides a balance of greater styling with easier ability for content managers to select from a pre-determined list of "For More Information" contact resources. The standard approach is to use ACCD information, but for COVID-19 releases this also adds the option to list the CoA Communications office _instead_. This list can always be expanded or contracted based on the need of the day.