### PR TITLE
Automate hourly production builds on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,3 +102,19 @@ jobs:
         path: /tmp/circleci-artifacts
     - store_artifacts:
         path: /tmp/circleci-test-results
+
+workflows:
+  version: 2
+  commit-workflow:
+    jobs:
+      - build 
+  scheduled-workflow:
+    triggers:
+      - schedule:
+          cron: "15 * * * *"
+          filters:
+            branches:
+              only: master
+
+    jobs:
+      - build


### PR DESCRIPTION
No more need for Heroku Scheduler now that CircleCI has workflows with CRON scheduling built in! This builds the site every hour, on the :15. CircleCI may shift this time by up to 10 minutes depending on request load at the scheduled time so it should not be treated as exact.