### PR TITLE
Introduce "Newsroom" nav construct

### DIFF
--- a/_assets/javascripts/main.js
+++ b/_assets/javascripts/main.js
@@ -1,6 +1,7 @@
 
 //= require photoswipe
 //= require click_tracking
+//= require meet_the_team
 
 var delegate = require("dom-delegate"), // https://github.com/ftlabs/ftdomdelegate
     folders = require("components/folders"),

--- a/_assets/javascripts/meet_the_team.js
+++ b/_assets/javascripts/meet_the_team.js
@@ -1,0 +1,8 @@
+$(document).ready(function () {
+  $('.acc-bio-toggle-button').click(function() {
+    $(this).next('.acc-employee-bio').show();
+  });
+  $('.acc-employee-bio').click(function() {
+    $(this).hide();
+  })
+});

--- a/_assets/stylesheets/components/nav.scss
+++ b/_assets/stylesheets/components/nav.scss
@@ -190,6 +190,16 @@
       @include navigation-gradient($acc-color-exhibit);
     }
   }
+  .acc-mega-nav-newsroom {
+    button:hover,
+    button:active,
+    button[aria-expanded=true] {
+      background-color: black;
+    }
+    .acc-subnav {
+      @include navigation-gradient(black);
+    }
+  }
 }
 
 .acc-menu-button {

--- a/_assets/stylesheets/components/nav.scss
+++ b/_assets/stylesheets/components/nav.scss
@@ -200,6 +200,16 @@
       @include navigation-gradient(black);
     }
   }
+  .acc-mega-nav-about {
+    button:hover,
+    button:active,
+    button[aria-expanded=true] {
+      background-color: $acc-color-attend;
+    }
+    .acc-subnav {
+      @include navigation-gradient($acc-color-attend);
+    }
+  }
 }
 
 .acc-menu-button {

--- a/_assets/stylesheets/elements/meet_the_team.scss
+++ b/_assets/stylesheets/elements/meet_the_team.scss
@@ -1,0 +1,61 @@
+.acc-meet-the-team {
+  text-align: center;
+  list-style: none;
+  padding-left: 0;
+  justify-content: space-between;
+}
+
+.acc-employee > div {
+  padding: 2em 1em 3em 1em;
+  background-color: $acc-color-gray-lightest;
+}
+.acc-employee-bio {
+  display: none;
+  position: fixed;
+  width: 60%;
+  left: 20%;
+  top: 20%;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background: rgba(0,0,0, .5);
+  z-index: 200;
+}
+.acc-employee-bio > div {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+}
+.acc-employee-bio {
+  > div {
+    > div {
+      padding: 1em;
+      text-align: left;
+      background-color: white;
+      width: 90%;
+      max-width: 800px;
+      max-height: 80%;
+      margin: 0 auto;
+      overflow: visible;
+      position: relative;
+      img {
+        position: absolute;
+        top: -20px;
+        right: -20px;
+        width: 45px;
+        height: 45px;
+        padding: 4px;
+        background-color: black;
+        border-radius: 50%;
+        cursor: pointer;
+      }
+      > div {
+        overflow-x: hidden;
+        overflow-y: auto;
+        height: 100%;
+      }
+    }
+  }
+}

--- a/_assets/stylesheets/main.scss
+++ b/_assets/stylesheets/main.scss
@@ -13,6 +13,7 @@
 @import "elements/lists";
 @import "elements/flex";
 @import "elements/press_release";
+@import "elements/meet_the_team";
 @import "components/nav";
 @import "components/footer";
 @import "components/folders";

--- a/_config.yml
+++ b/_config.yml
@@ -119,6 +119,11 @@ defaults:
       layout: contact
   -
     scope:
+      type: "meet-the-team"
+    values:
+      layout: meet_the_team
+  -
+    scope:
       type: "plans"
     values:
       layout: floor_plan

--- a/_config.yml
+++ b/_config.yml
@@ -102,10 +102,16 @@ defaults:
       permalink: "/events/:year/:month/"
   -
     scope:
-      type: newsroom
+      type: press-releases
     values:
       layout: press_release
-      permalink: "/newsroom/:title/"
+      permalink: "/press-releases/:title/"
+  -
+    scope:
+      type: "inTheNews"
+    values:
+      layout: accd-in-the-news
+      permalink: "/in_the_news/:title/"
   -
     scope:
       type: "contact"

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -33,7 +33,6 @@ module Jekyll
 
       if press_releases_section = site.collections["press-releases"]
         data.fetch("pressRelease", []).each do |attributes|
-#           puts "doing press release item fetch"
           attributes["date"] = attributes["date"].utc # Undo implicit time zone conversion
           page = generate_page(site, press_releases_section, attributes)
           page.data["breadcrumbs"][-1]["title"] = attributes["date"].strftime("%B %-d, %Y")
@@ -42,19 +41,8 @@ module Jekyll
         end
       end
 
-#       site.collections.each do |c|
-#         puts "Collection:"
-#         puts c
-#         puts "^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^"
-#       end
-      #puts "hello between"
-      #puts "#{site.collections}"
-      #puts "done bwteen"
-
       if in_the_news_section = site.collections["in-the-news"]
         data.fetch("inTheNews", []).each do |attributes|
-          puts "in the news item. #{attributes}"
-          puts "* * * * * *"
           attributes["date"] = attributes["date"].utc # Undo implicit time zone conversion
           page = generate_page(site, in_the_news_section, attributes)
           page.data["breadcrumbs"][-1]["title"] = attributes["date"].strftime("%B %-d, %Y")

--- a/_plugins/generators/contentful.rb
+++ b/_plugins/generators/contentful.rb
@@ -31,13 +31,36 @@ module Jekyll
         generate_page(site, section, attributes)
       end
 
-      if press_releases_section = site.collections["newsroom"]
+      if press_releases_section = site.collections["press-releases"]
         data.fetch("pressRelease", []).each do |attributes|
+#           puts "doing press release item fetch"
           attributes["date"] = attributes["date"].utc # Undo implicit time zone conversion
           page = generate_page(site, press_releases_section, attributes)
           page.data["breadcrumbs"][-1]["title"] = attributes["date"].strftime("%B %-d, %Y")
           page.data["photo_url"] = attributes["picture"]["url"] if attributes["picture"].present?
           page.data["preview_text"] = attributes["previewText"] if attributes["previewText"].present?
+        end
+      end
+
+#       site.collections.each do |c|
+#         puts "Collection:"
+#         puts c
+#         puts "^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^ ^"
+#       end
+      #puts "hello between"
+      #puts "#{site.collections}"
+      #puts "done bwteen"
+
+      if in_the_news_section = site.collections["in-the-news"]
+        data.fetch("inTheNews", []).each do |attributes|
+          puts "in the news item. #{attributes}"
+          puts "* * * * * *"
+          attributes["date"] = attributes["date"].utc # Undo implicit time zone conversion
+          page = generate_page(site, in_the_news_section, attributes)
+          page.data["breadcrumbs"][-1]["title"] = attributes["date"].strftime("%B %-d, %Y")
+          page.data["photo_url"] = attributes["photo"]["url"] if attributes["photo"].present?
+          page.data["preview_text"] = attributes["previewText"] if attributes["previewText"].present?
+          page.data["publication_url"] = attributes["publicationUrl"]
         end
       end
     end

--- a/_templates/in-the-news.html
+++ b/_templates/in-the-news.html
@@ -1,0 +1,45 @@
+---
+layout: default
+---
+{% include components/content_blocks.html blocks=page.contentful.contentBlocks %}
+
+<div class="acc-full">
+  <div class="acc-flex no-break">
+    <div class="acc-flex-two-thirds">
+      {%- assign items = site.in-the-news | sort: "date" | reverse -%}
+      {%- for item in items limit:3 -%}
+      <div class="acc-side-by-side-container">
+        <div class="acc-flex break-medium">
+          <div class="acc-flex-one-half">
+            <div class="acc-side-by-side-component">
+              <a href="{{ item.publication_url }}">
+                <img src="{{ item.photo_url }}?w=900&h=410" />
+              </a>
+            </div>
+          </div>
+          <div class="acc-flex-one-half">
+            <div class="acc-side-by-side-component">
+              <strong>{{ press_release.date | date: "%B %-d, %Y" }}</strong>
+              <h3><a href="{{ item.publication_url }}">{{ item.title }}</a></h3>
+              {% if item.preview_text %}
+                {{ item.preview_text }}
+              {% endif %}
+              <p>
+                <a href="{{item.publication_url}}" class="acc-button">Read More</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      {%- endfor -%}
+      <ul class="acc-unstyled-list acc-press-release-list">
+        {%- for item in items offset:3 -%}
+        <li>
+          <strong class="acc-press-release-date">{{ item.date | date: "%B %-d, %Y" }}</strong><br>
+          <a href="{{ item.url }}">{{ item.title }}</a>
+        </li>
+        {%- endfor -%}
+      </ul>
+    </div>
+  </div>
+</div>

--- a/_templates/meet-the-team.html
+++ b/_templates/meet-the-team.html
@@ -1,0 +1,41 @@
+---
+layout: default
+---
+
+<main id="main-content">
+  {%- for banner in page.contentful.contentBlocks limit: 1 -%}
+    <div class="acc-page-banner">
+      <h1 style="background-image: url('{{ banner.backgroundImage.url }}?w=1200&fm=jpg&fl=progressive');">
+        <div class="acc-page-banner-overlay"></div>
+        <span>{{ banner.title }}</span>
+      </h1>
+    </div>
+  {%- endfor -%}
+
+  <div class="acc-flex break-medium">
+    <h2 class="acc-flex-one-half">Executive Team</h2>
+  </div>
+
+  <ul class="acc-flex break-large acc-meet-the-team">
+    {%- for employee in page.contentful.contentBlocks offset: 1 -%}
+      <li class="acc-flex-thirds acc-employee">
+        <div>
+          <img src="{{ employee.photo.url }}?w=330&h=220&fit=thumb" alt="{{ item.photo.title }}" />
+          <h3>{{ employee.name }}</h3>
+          <h4>{{ employee.title }}</h4>
+          <a href="#" class="acc-bio-toggle-button" aria-hidden="true">Read Biography</a>
+          <div class="acc-employee-bio" aria-hidden="false">
+            <div>
+              <div>
+                <div>
+                  {{ employee.biography | markdownify }}
+                </div>
+                <img src="{{site.baseurl}}/assets/icons/button-close.png" aria-hidden="true" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+    {%- endfor -%}
+  </ul>
+</main>

--- a/_templates/press-releases.html
+++ b/_templates/press-releases.html
@@ -7,7 +7,7 @@ contentful_id: 4S1U5bQghaQAaKQsqOKywe
 <div class="acc-full">
   <div class="acc-flex no-break">
     <div class="acc-flex-two-thirds">
-      {%- assign press_releases = site.newsroom | sort: "date" | reverse -%}
+      {%- assign press_releases = site.press-releases | sort: "date" | reverse -%}
       {%- for press_release in press_releases limit:3 -%}
       <div class="acc-side-by-side-container">
         <div class="acc-flex break-medium">


### PR DESCRIPTION
A Newsroom navigation item has been added to provide greater flexibility around corporate communications/messaging. The initial release includes Press Releases (formerly Newsroom, formerly Press Room, formerly Press Releases) and a new "In The News" section, for 3rd-party articles/media written _about_ ACCD instead of _by_ ACCD.

Future Newsroom pages will include Expansion Plans and likely some contact/Meet The Team stuff.

This required additions and edits to the Contentful Content Models.