### PR TITLE
Re-add auto-deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,13 +113,13 @@ workflows:
   commit-workflow:
     jobs:
       - build 
-#   scheduled-workflow:
-#     triggers:
-#       - schedule:
-#           cron: "15 * * * *"
-#           filters:
-#             branches:
-#               only: master
-# 
-#     jobs:
-#       - build
+  scheduled-workflow:
+    triggers:
+      - schedule:
+          cron: "15 * * * *"
+          filters:
+            branches:
+              only: master
+
+    jobs:
+      - build


### PR DESCRIPTION
Now that the new subsections (especially Meet The Team) are in-place the Content Model is no longer undergoing breaking changes.