### PR TITLE
Remove scheduled builds from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,13 +113,3 @@ workflows:
   commit-workflow:
     jobs:
       - build 
-  scheduled-workflow:
-    triggers:
-      - schedule:
-          cron: "15 * * * *"
-          filters:
-            branches:
-              only: master
-
-    jobs:
-      - build


### PR DESCRIPTION
Content managers are now able to use their CoA AzureAD credentials to access the web admin dashboard, allowing us to free up these auto-build resources while reducing almost all friction around manual deployments.