### PR TITLE
Update PEC homepage elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ layout: default
   </h1>
   <div class="acc-page-banner-text-container">
     {{ banner.text | markdownify }}
-  </div>		
+  </div>
 </div>
 
 {%- if site.title == 'Austin Convention Center' -%}
@@ -33,7 +33,7 @@ layout: default
       <div class="acc-flex break-medium">
         <div class="acc-flex-one-half">
           <div class="acc-side-by-side-component acc-homepage-youtube-embed">
-            <iframe src="https://www.youtube.com/embed/le8J6w4uSIE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe src="https://www.youtube.com/embed/9tzecTmxwJg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
           </div>
         </div>
         <div class="acc-flex-one-half">
@@ -46,6 +46,29 @@ layout: default
             </p>
             <p>
               When you're ready, rest assured the Austin Convention Center will be the most well prepared event space in the country.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+{%- elsif site.title == 'Palmer Events Center' -%}
+  <div class="acc-mega-feature acc-color-theme-Default acc-video-embed-mega-feature">
+    <div class="acc-side-by-side-container">
+      <div class="acc-flex break-medium">
+        <div class="acc-flex-one-half">
+          <div class="acc-side-by-side-component acc-homepage-youtube-embed">
+            <iframe src="https://www.youtube.com/embed/OoeV6e9epXE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          </div>
+        </div>
+        <div class="acc-flex-one-half">
+          <div class="acc-side-by-side-component">
+            <h3>
+              Virtual and Hybrid Events
+            </h3>
+            <p>
+              Palmer Events Center provides industry-leading bandwidth to stream your event with an incredible backdrop of the Austin skyline at a fraction of the cost of similar venues. Contact our sales team to learn more about how you can stream your virtual or hybrid event from Palmer Events Center.
             </p>
           </div>
         </div>
@@ -74,7 +97,9 @@ layout: default
 </div>
 
 {% assign mega_feature = contentful.contentBlocks | last %}
-{% include components/content_blocks/mega_feature.html block=mega_feature %}
+{%- if site.title == 'Austin Convention Center' -%}
+  {% include components/content_blocks/mega_feature.html block=mega_feature %}
+{%- endif -%}
 
 <div class="acc-full acc-social-container">
   {% assign socialMediaHeader = contentful.contentBlocks | where: "title", "social-media-header" | first %}


### PR DESCRIPTION
The original implementation of the homepage video mega feature was limited to just the ACC site, but now that the PEC video has been produced we'll use the feature on both sites. For now it's still hard-coded until we have a discussion around a proper video feature spec. Until then, one-off updates for one-off tasks until a pattern emerges.

The marketing team also requested that the current Mega Feature photo gallery teaser be removed from PEC, at least temporarily, hence the conditional logic there. The Mega Feature Content Item has been unpublished and removed from the Homepage Content Blocks in Contentful, but remains intact and configured to be re-introduced any time in the future.