### PR TITLE
Add support for team photo on Meet The Team page

### DIFF
--- a/_assets/stylesheets/elements/meet_the_team.scss
+++ b/_assets/stylesheets/elements/meet_the_team.scss
@@ -4,6 +4,12 @@
   padding-left: 0;
   justify-content: space-between;
 }
+.acc-meet-the-team-photo-wrapper {
+  margin-top: -4em;
+  img {
+    width: 100%;
+  }
+}
 
 .acc-employee > div {
   padding: 2em 1em 3em 1em;

--- a/_templates/meet-the-team.html
+++ b/_templates/meet-the-team.html
@@ -7,6 +7,11 @@ layout: default
     {% include components/content_blocks/page_banner.html block=banner %}
   {%- endfor -%}
 
+  {%- if page.contentful.file -%}
+    <div class="acc-flex break-large acc-meet-the-team-photo-wrapper">
+      <img src="{{ page.contentful.file.url }}?w=1200&fm=jpg&fl=progressive" alt="Photo of the ACCD executive team" />
+    </div>
+  {%- endif -%}
   <div class="acc-flex break-medium">
     <h2 class="acc-flex-one-half">Executive Team</h2>
   </div>


### PR DESCRIPTION
This change allows a content editor in Contentful to add a team image as a File on the Meet The Team page. If this file is present, the template will render that image full-width between the page banner and executive bios.